### PR TITLE
Fixes for no gradients in seq file.

### DIFF
--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -499,6 +499,8 @@ function read_Grad(gradLibrary, shapeLibrary, Δt_gr, i)
             gT = (gt[2:end] .- gt[1:end-1]) * Δt_gr
             G = Grad(gA,gT,0,0,delay)
         end
+    else
+	# gradient is not present, set to zero from above
     end
     G
 end

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -476,7 +476,7 @@ Reads the gradient. It is used internally by [`get_block`](@ref).
 """
 function read_Grad(gradLibrary, shapeLibrary, Δt_gr, i)
     G = Grad(0,0)
-    if gradLibrary.count == 0
+    if gradLibrary == Dict() # no gradient info in seq
         # no gradients, set to zero from above
     elseif gradLibrary[i]["type"] == 't' #if trapezoidal gradient
         #(1)amplitude (2)rise (3)flat (4)fall (5)delay

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -476,7 +476,9 @@ Reads the gradient. It is used internally by [`get_block`](@ref).
 """
 function read_Grad(gradLibrary, shapeLibrary, Δt_gr, i)
     G = Grad(0,0)
-    if gradLibrary[i]["type"] == 't' #if trapezoidal gradient
+    if gradLibrary.count == 0
+        # no gradients, set to zero from above
+    elseif gradLibrary[i]["type"] == 't' #if trapezoidal gradient
         #(1)amplitude (2)rise (3)flat (4)fall (5)delay
         g_A, g_rise, g_T, g_fall, g_delay = gradLibrary[i]["data"]
         G = Grad(g_A,g_T,g_rise,g_fall,g_delay)
@@ -499,8 +501,6 @@ function read_Grad(gradLibrary, shapeLibrary, Δt_gr, i)
             gT = (gt[2:end] .- gt[1:end-1]) * Δt_gr
             G = Grad(gA,gT,0,0,delay)
         end
-    else
-	# gradient is not present, set to zero from above
     end
     G
 end

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -481,7 +481,7 @@ function read_Grad(gradLibrary, shapeLibrary, Δt_gr, i)
         return G
     elseif isempty(gradLibrary) #isempty(gradLibrary) checked first or error below
         #No gradient shapes defined in seq file, set G to zero from above
-        @error "No gradients defined in seq file, but id $i used in block."
+        @error "No gradients defined in seq file [GRADIENTS] or [TRAP] sections, but id $i used in [BLOCKS]."
     elseif gradLibrary[i]["type"] == 't' #if trapezoidal gradient
         #(1)amplitude (2)rise (3)flat (4)fall (5)delay
         g_A, g_rise, g_T, g_fall, g_delay = gradLibrary[i]["data"]

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -480,7 +480,7 @@ function read_Grad(gradLibrary, shapeLibrary, Δt_gr, i)
         #(1)amplitude (2)rise (3)flat (4)fall (5)delay
         g_A, g_rise, g_T, g_fall, g_delay = gradLibrary[i]["data"]
         G = Grad(g_A,g_T,g_rise,g_fall,g_delay)
-    elseif gradLibrary[i]["type"] == 'g' #Arbitrary gradient waveform
+    elseif gradLibrary[i]["type"] == 'g' && i!=0 #Arbitrary gradient waveform, fix from https://github.com/JuliaHealth/KomaMRI.jl/discussions/311#discussion-6251011
         #(1)amplitude (2)amp_shape_id (3)time_shape_id (4)delay
         g = gradLibrary[i]["data"]
         amplitude =     g[1]

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -476,13 +476,17 @@ Reads the gradient. It is used internally by [`get_block`](@ref).
 """
 function read_Grad(gradLibrary, shapeLibrary, Δt_gr, i)
     G = Grad(0,0)
-    if gradLibrary == Dict() # no gradient info in seq
-        # no gradients, set to zero from above
+    if i==0 
+        #No gradient in this block, i==0 is reserved for this case
+        return G
+    elseif isempty(gradLibrary) #isempty(gradLibrary) checked first or error below
+        #No gradient shapes defined in seq file, set G to zero from above
+        @error "No gradients defined in seq file, but id $i used in block."
     elseif gradLibrary[i]["type"] == 't' #if trapezoidal gradient
         #(1)amplitude (2)rise (3)flat (4)fall (5)delay
         g_A, g_rise, g_T, g_fall, g_delay = gradLibrary[i]["data"]
         G = Grad(g_A,g_T,g_rise,g_fall,g_delay)
-    elseif gradLibrary[i]["type"] == 'g' && i!=0 #Arbitrary gradient waveform, fix from https://github.com/JuliaHealth/KomaMRI.jl/discussions/311#discussion-6251011
+    elseif gradLibrary[i]["type"] == 'g' #Arbitrary gradient waveform, fix from https://github.com/JuliaHealth/KomaMRI.jl/discussions/311#discussion-6251011
         #(1)amplitude (2)amp_shape_id (3)time_shape_id (4)delay
         g = gradLibrary[i]["data"]
         amplitude =     g[1]


### PR DESCRIPTION
#311


Added cases to:

`read_Grad(gradLibrary, shapeLibrary, Δt_gr, i)`

to detect empty gradLibrary dictionary.


Also includes the fix suggested from:

https://github.com/JuliaHealth/KomaMRI.jl/discussions/311#discussion-6251011


Test with fid.seq from:

https://github.com/pulseq/pulseq/blob/master/tests/fid.seq

![fid_seq_test](https://github.com/JuliaHealth/KomaMRI.jl/assets/1796102/488c2349-d347-41dc-b3e3-c9ac84f0090a)

![ge_seq_test_data](https://github.com/JuliaHealth/KomaMRI.jl/assets/1796102/575c26c0-ea3b-492e-b17c-3881e57d30a4)


Test with ge.seq from:

https://github.com/JuliaHealth/KomaMRI.jl/blob/master/examples/1.sequences/ge.seq

julia> KomaUI()
[ Info: Listening on: 127.0.0.1:4534, thread id: 1
[ Info: Loaded `Scanner` to `sys_ui[]`
[ Info: Loaded `Sequence` to `seq_ui[]`
[ Info: Loaded `Phantom` to `obj_ui[]`
[ Info: Loaded `RawAcquisitionData` to `raw_ui[]`
[ Info: Loaded image to `img_ui[]`
┌ Info: 2 CUDA capable device(s).
│   (0*) = "Quadro RTX 8000"
└   (1 ) = "Quadro RTX 8000"
┌ Info: Currently using package versions
│   KomaMRI = "0.8.0"
│   KomaMRICore = "0.8.1"
│   KomaMRIFiles = "0.8.0"
└   KomaMRIPlots = "0.8.0"

julia> [ Info: Loading sequence ge.seq ...
┌ Info: Running simulation in the GPU (Quadro RTX 8000)
│   koma_version = v"0.8.1"
│   sim_method = Bloch()
│   spins = 6506
│   time_points = 20372
└   adc_points = 10100
Progress: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| Time: 0:00:48
  simulated_blocks:  620
  rf_blocks:         305
  acq_samples:       10100
 48.855502 seconds (51.92 M allocations: 3.291 GiB, 1.79% gc time, 76.73% compilation time: <1% of which was recompilation)
[ Info: Exporting to ISMRMRD file: /tmp/Koma_signal.mrd
[ Info: Running reconstruction ...

![ge_seq_test](https://github.com/JuliaHealth/KomaMRI.jl/assets/1796102/ab66a620-4430-4b96-9b01-4a9299ef8649)

![ge_seq_test_data](https://github.com/JuliaHealth/KomaMRI.jl/assets/1796102/2884f703-c2f6-4bcf-a9db-8180d1a792de)

![ge_seq_test_image](https://github.com/JuliaHealth/KomaMRI.jl/assets/1796102/4193885b-77ec-40d3-acc9-3e9c227c2fb6)
