### PR TITLE
Resolving type conflicts when passing structures to GPU

### DIFF
--- a/KomaMRICore/src/simulation/GPUFunctions.jl
+++ b/KomaMRICore/src/simulation/GPUFunctions.jl
@@ -40,7 +40,7 @@ _isleaf(x) = _isbitsarray(x) || isleaf(x)
 
 # GPU adaptor
 struct KomaCUDAAdaptor end
-adapt_storage(to::KomaCUDAAdaptor, x) = CUDA.cu(x)
+adapt_storage(to::KomaCUDAAdaptor, x) = adapt(CuArray, x)
 
 """
 	gpu(x)


### PR DESCRIPTION
This PR solves the following bug:

`phantom = brain_phantom2D()`
Phantom{Float64}
  name: String "brain2D_axial"
  x: Array{Float64}((6506,)) [-0.084, -0.084, -0.084, -0.084, -0.084, -0.084, -0.084, -0.084, -0.084, -0.084  … ]
  y: Array{Float64}((6506,)) [-0.03, -0.028, -0.026, -0.024, -0.022, -0.02, -0.018, -0.016, -0.014, -0.012  …  ]
  z: Array{Float64}((6506,)) [-0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0  … ]
  ρ: Array{Float64}((6506,)) [0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7  … ]
  T1: Array{Float64}((6506,)) [0.5690000000000001, 0.5690000000000001, ... ]
  T2: Array{Float64}((6506,)) [0.329, 0.329, 0.329, 0.329, 0.329, 0.329, 0.329, 0.329, 0.329, 0.329  … ]
  T2s: Array{Float64}((6506,)) [0.058, 0.058, 0.058, 0.058, 0.058, 0.058, 0.058, 0.058, 0.058, 0.058  … ]
  Δw: Array{Float64}((6506,)) [-0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0  … ]
  Dλ1: Array{Float64}((6506,)) [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  … ]
  Dλ2: Array{Float64}((6506,)) [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  … ]
  Dθ: Array{Float64}((6506,)) [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  … ]
  ...

`phantom |> gpu`
Phantom{Float32}
  name: String "brain2D_axial"
  x: CUDA.CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}
  y: CUDA.CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}
  z: CUDA.CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}
  ρ: CUDA.CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}
  T1: CUDA.CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}
  T2: CUDA.CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}
  T2s: CUDA.CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}
  Δw: CUDA.CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}
  Dλ1: CUDA.CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}
  Dλ2: CUDA.CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}
  Dθ: CUDA.CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}
  ...


Eltype of arrays inside the struct is converted to Float32. This is undesired.
A simple change (`CUDA.cu(x)` -> `CUDA.adapt(CuArray, x)`) solves this problem