### PR TITLE
CI: Update `codecov-action` to v4.1.1, and pass the organization-wide `CODECOV_TOKEN` secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,10 +132,12 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: KomaMRIFiles/src
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@c16abc29c95fcf9174b58eb7e1abf4c866893bc8 # v4.1.1
         with:
           files: lcov.info
           flags: files
+          token: ${{ secrets.CODECOV_TOKEN }} # required
+          fail_ci_if_error: true
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,31 +104,39 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@c16abc29c95fcf9174b58eb7e1abf4c866893bc8 # v4.1.1
         with:
           files: lcov.info
           flags: komamri
+          token: ${{ secrets.CODECOV_TOKEN }} # required
+          fail_ci_if_error: true
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: KomaMRIBase/src
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@c16abc29c95fcf9174b58eb7e1abf4c866893bc8 # v4.1.1
         with:
           files: lcov.info
           flags: base
+          token: ${{ secrets.CODECOV_TOKEN }} # required
+          fail_ci_if_error: true
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: KomaMRICore/src
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@c16abc29c95fcf9174b58eb7e1abf4c866893bc8 # v4.1.1
         with:
           files: lcov.info
           flags: core
+          token: ${{ secrets.CODECOV_TOKEN }} # required
+          fail_ci_if_error: true
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: KomaMRIPlots/src
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@c16abc29c95fcf9174b58eb7e1abf4c866893bc8 # v4.1.1
         with:
           files: lcov.info
           flags: plots
+          token: ${{ secrets.CODECOV_TOKEN }} # required
+          fail_ci_if_error: true
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: KomaMRIFiles/src


### PR DESCRIPTION
Ref #335

Note: this PR pins the `codecov/codecov-action` action to the full-length commit hash. When we pin actions to commit hashes, I often recommend setting up Dependabot to keep those commit hashes up-to-date. See https://github.com/JuliaHealth/KomaMRI.jl/pull/336