### PR TITLE
Fix some test failures

### DIFF
--- a/KomaMRICore/ext/KomaAMDGPUExt.jl
+++ b/KomaMRICore/ext/KomaAMDGPUExt.jl
@@ -10,19 +10,6 @@ KomaMRICore.set_device!(::ROCBackend, dev_idx::Integer) = AMDGPU.device_id!(dev_
 KomaMRICore.set_device!(::ROCBackend, dev::AMDGPU.HIPDevice) = AMDGPU.device!(dev)
 KomaMRICore.device_name(::ROCBackend) = AMDGPU.device().name
 
-Adapt.adapt_storage(::ROCBackend, x::KomaMRICore.NoMotion) = KomaMRICore.NoMotion{Float32}()
-Adapt.adapt_storage(::ROCBackend, x::KomaMRICore.SimpleMotion) = KomaMRICore.f32(x)
-function Adapt.adapt_storage(::ROCBackend, x::KomaMRICore.ArbitraryMotion)
-    fields = []
-    for field in fieldnames(KomaMRICore.ArbitraryMotion)
-        if field in (:ux, :uy, :uz) 
-            push!(fields, Adapt.adapt(ROCBackend(), getfield(x, field)))
-        else
-            push!(fields, KomaMRICore.f32(getfield(x, field)))
-        end
-    end
-    return KomaMRICore.ArbitraryMotion(fields...)
-end
 function Adapt.adapt_storage(
     ::ROCBackend, x::Vector{KomaMRICore.LinearInterpolator{T,V}}
 ) where {T<:Real,V<:AbstractVector{T}}

--- a/KomaMRICore/ext/KomaAMDGPUExt.jl
+++ b/KomaMRICore/ext/KomaAMDGPUExt.jl
@@ -10,6 +10,7 @@ KomaMRICore.set_device!(::ROCBackend, dev_idx::Integer) = AMDGPU.device_id!(dev_
 KomaMRICore.set_device!(::ROCBackend, dev::AMDGPU.HIPDevice) = AMDGPU.device!(dev)
 KomaMRICore.device_name(::ROCBackend) = AMDGPU.device().name
 
+Adapt.adapt_storage(::ROCBackend, x::KomaMRICore.NoMotion) = KomaMRICore.NoMotion{Float32}()
 Adapt.adapt_storage(::ROCBackend, x::KomaMRICore.SimpleMotion) = KomaMRICore.f32(x)
 function Adapt.adapt_storage(::ROCBackend, x::KomaMRICore.ArbitraryMotion)
     fields = []

--- a/KomaMRICore/ext/KomaAMDGPUExt.jl
+++ b/KomaMRICore/ext/KomaAMDGPUExt.jl
@@ -9,19 +9,19 @@ KomaMRICore.set_device!(::ROCBackend, dev_idx::Integer) = AMDGPU.device_id!(dev_
 KomaMRICore.set_device!(::ROCBackend, dev::AMDGPU.HIPDevice) = AMDGPU.device!(dev)
 KomaMRICore.device_name(::ROCBackend) = AMDGPU.device().name
 
-function adapt_storage(::ROCBackend, x::ArbitraryMotion)
+function adapt_storage(::ROCBackend, x::KomaMRICore.ArbitraryMotion)
     fields = []
-    for field in fieldnames(ArbitraryMotion)
+    for field in fieldnames(KomaMRICore.ArbitraryMotion)
         if field in (:ux, :uy, :uz) 
-            push!(fields, adapt(::ROCBackend, getfield(x, field)))
+            push!(fields, adapt(ROCBackend(), getfield(x, field)))
         else
             push!(fields, f32(getfield(x, field)))
         end
     end
-    return ArbitraryMotion(fields...)
+    return KomaMRICore.ArbitraryMotion(fields...)
 end
 function adapt_storage(
-    ::ROCBackend, x::Vector{LinearInterpolator{T,V}}
+    ::ROCBackend, x::Vector{KomaMRICore.LinearInterpolator{T,V}}
 ) where {T<:Real,V<:AbstractVector{T}}
     return AMDGPU.rocconvert.(x)
 end

--- a/KomaMRICore/ext/KomaAMDGPUExt.jl
+++ b/KomaMRICore/ext/KomaAMDGPUExt.jl
@@ -9,6 +9,23 @@ KomaMRICore.set_device!(::ROCBackend, dev_idx::Integer) = AMDGPU.device_id!(dev_
 KomaMRICore.set_device!(::ROCBackend, dev::AMDGPU.HIPDevice) = AMDGPU.device!(dev)
 KomaMRICore.device_name(::ROCBackend) = AMDGPU.device().name
 
+function adapt_storage(::ROCBackend, x::ArbitraryMotion)
+    fields = []
+    for field in fieldnames(ArbitraryMotion)
+        if field in (:ux, :uy, :uz) 
+            push!(fields, adapt(::ROCBackend, getfield(x, field)))
+        else
+            push!(fields, f32(getfield(x, field)))
+        end
+    end
+    return ArbitraryMotion(fields...)
+end
+function adapt_storage(
+    ::ROCBackend, x::Vector{LinearInterpolator{T,V}}
+) where {T<:Real,V<:AbstractVector{T}}
+    return AMDGPU.rocconvert.(x)
+end
+
 function KomaMRICore._print_devices(::ROCBackend)
     devices = [
         Symbol("($(i-1)$(i == 1 ? "*" : " "))") => d.name for

--- a/KomaMRICore/ext/KomaCUDAExt.jl
+++ b/KomaMRICore/ext/KomaCUDAExt.jl
@@ -8,6 +8,23 @@ KomaMRICore.isfunctional(::CUDABackend) = CUDA.functional()
 KomaMRICore.set_device!(::CUDABackend, val) = CUDA.device!(val)
 KomaMRICore.device_name(::CUDABackend) = CUDA.name(CUDA.device())
 
+function adapt_storage(::CUDABackend, x::ArbitraryMotion)
+    fields = []
+    for field in fieldnames(ArbitraryMotion)
+        if field in (:ux, :uy, :uz) 
+            push!(fields, adapt(::CUDABackend, getfield(x, field)))
+        else
+            push!(fields, f32(getfield(x, field)))
+        end
+    end
+    return ArbitraryMotion(fields...)
+end
+function adapt_storage(
+    ::CUDABackend, x::Vector{LinearInterpolator{T,V}}
+) where {T<:Real,V<:AbstractVector{T}}
+    return CUDA.cu.(x)
+end
+
 function KomaMRICore._print_devices(::CUDABackend)
     devices = [
         Symbol("($(i-1)$(i == 1 ? "*" : " "))") => CUDA.name(d) for

--- a/KomaMRICore/ext/KomaCUDAExt.jl
+++ b/KomaMRICore/ext/KomaCUDAExt.jl
@@ -8,19 +8,19 @@ KomaMRICore.isfunctional(::CUDABackend) = CUDA.functional()
 KomaMRICore.set_device!(::CUDABackend, val) = CUDA.device!(val)
 KomaMRICore.device_name(::CUDABackend) = CUDA.name(CUDA.device())
 
-function adapt_storage(::CUDABackend, x::ArbitraryMotion)
+function adapt_storage(::CUDABackend, x::KomaMRICore.ArbitraryMotion)
     fields = []
-    for field in fieldnames(ArbitraryMotion)
+    for field in fieldnames(KomaMRICore.ArbitraryMotion)
         if field in (:ux, :uy, :uz) 
-            push!(fields, adapt(::CUDABackend, getfield(x, field)))
+            push!(fields, adapt(CUDABackend(), getfield(x, field)))
         else
             push!(fields, f32(getfield(x, field)))
         end
     end
-    return ArbitraryMotion(fields...)
+    return KomaMRICore.ArbitraryMotion(fields...)
 end
 function adapt_storage(
-    ::CUDABackend, x::Vector{LinearInterpolator{T,V}}
+    ::CUDABackend, x::Vector{KomaMRICore.LinearInterpolator{T,V}}
 ) where {T<:Real,V<:AbstractVector{T}}
     return CUDA.cu.(x)
 end

--- a/KomaMRICore/ext/KomaCUDAExt.jl
+++ b/KomaMRICore/ext/KomaCUDAExt.jl
@@ -9,6 +9,7 @@ KomaMRICore.isfunctional(::CUDABackend) = CUDA.functional()
 KomaMRICore.set_device!(::CUDABackend, val) = CUDA.device!(val)
 KomaMRICore.device_name(::CUDABackend) = CUDA.name(CUDA.device())
 
+Adapt.adapt_storage(::CUDABackend, x::KomaMRICore.NoMotion) = KomaMRICore.NoMotion{Float32}()
 Adapt.adapt_storage(::CUDABackend, x::KomaMRICore.SimpleMotion) = KomaMRICore.f32(x)
 function Adapt.adapt_storage(::CUDABackend, x::KomaMRICore.ArbitraryMotion)
     fields = []

--- a/KomaMRICore/ext/KomaCUDAExt.jl
+++ b/KomaMRICore/ext/KomaCUDAExt.jl
@@ -9,23 +9,10 @@ KomaMRICore.isfunctional(::CUDABackend) = CUDA.functional()
 KomaMRICore.set_device!(::CUDABackend, val) = CUDA.device!(val)
 KomaMRICore.device_name(::CUDABackend) = CUDA.name(CUDA.device())
 
-Adapt.adapt_storage(::CUDABackend, x::KomaMRICore.NoMotion) = KomaMRICore.NoMotion{Float32}()
-Adapt.adapt_storage(::CUDABackend, x::KomaMRICore.SimpleMotion) = KomaMRICore.f32(x)
-function Adapt.adapt_storage(::CUDABackend, x::KomaMRICore.ArbitraryMotion)
-    fields = []
-    for field in fieldnames(KomaMRICore.ArbitraryMotion)
-        if field in (:ux, :uy, :uz) 
-            push!(fields, Adapt.adapt(CUDABackend(), getfield(x, field)))
-        else
-            push!(fields, KomaMRICore.f32(getfield(x, field)))
-        end
-    end
-    return KomaMRICore.ArbitraryMotion(fields...)
-end
 function Adapt.adapt_storage(
     ::CUDABackend, x::Vector{KomaMRICore.LinearInterpolator{T,V}}
 ) where {T<:Real,V<:AbstractVector{T}}
-    return CUDA.cu.(x)
+    return Adapt.adapt.(CuArray, x)
 end
 
 function KomaMRICore._print_devices(::CUDABackend)

--- a/KomaMRICore/ext/KomaMetalExt.jl
+++ b/KomaMRICore/ext/KomaMetalExt.jl
@@ -9,6 +9,23 @@ KomaMRICore.set_device!(::MetalBackend, device_index::Integer) = device_index ==
 KomaMRICore.set_device!(::MetalBackend, dev::Metal.MTLDevice) = Metal.device!(dev)
 KomaMRICore.device_name(::MetalBackend) = String(Metal.current_device().name)
 
+function adapt_storage(::MetalBackend, x::ArbitraryMotion)
+    fields = []
+    for field in fieldnames(ArbitraryMotion)
+        if field in (:ux, :uy, :uz) 
+            push!(fields, adapt(::MetalBackend, getfield(x, field)))
+        else
+            push!(fields, f32(getfield(x, field)))
+        end
+    end
+    return ArbitraryMotion(fields...)
+end
+function adapt_storage(
+    ::MetalBackend, x::Vector{LinearInterpolator{T,V}}
+) where {T<:Real,V<:AbstractVector{T}}
+    return Metal.mtl.(x)
+end
+
 function KomaMRICore._print_devices(::MetalBackend)
     @info "Metal device type: $(KomaMRICore.device_name(MetalBackend()))"
 end

--- a/KomaMRICore/ext/KomaMetalExt.jl
+++ b/KomaMRICore/ext/KomaMetalExt.jl
@@ -10,6 +10,7 @@ KomaMRICore.set_device!(::MetalBackend, device_index::Integer) = device_index ==
 KomaMRICore.set_device!(::MetalBackend, dev::Metal.MTLDevice) = Metal.device!(dev)
 KomaMRICore.device_name(::MetalBackend) = String(Metal.current_device().name)
 
+Adapt.adapt_storage(::MetalBackend, x::KomaMRICore.NoMotion) = KomaMRICore.NoMotion{Float32}()
 Adapt.adapt_storage(::MetalBackend, x::KomaMRICore.SimpleMotion) = KomaMRICore.f32(x)
 function Adapt.adapt_storage(::MetalBackend, x::KomaMRICore.ArbitraryMotion)
     fields = []

--- a/KomaMRICore/ext/KomaMetalExt.jl
+++ b/KomaMRICore/ext/KomaMetalExt.jl
@@ -10,19 +10,6 @@ KomaMRICore.set_device!(::MetalBackend, device_index::Integer) = device_index ==
 KomaMRICore.set_device!(::MetalBackend, dev::Metal.MTLDevice) = Metal.device!(dev)
 KomaMRICore.device_name(::MetalBackend) = String(Metal.current_device().name)
 
-Adapt.adapt_storage(::MetalBackend, x::KomaMRICore.NoMotion) = KomaMRICore.NoMotion{Float32}()
-Adapt.adapt_storage(::MetalBackend, x::KomaMRICore.SimpleMotion) = KomaMRICore.f32(x)
-function Adapt.adapt_storage(::MetalBackend, x::KomaMRICore.ArbitraryMotion)
-    fields = []
-    for field in fieldnames(KomaMRICore.ArbitraryMotion)
-        if field in (:ux, :uy, :uz) 
-            push!(fields, Adapt.adapt(MetalBackend(), getfield(x, field)))
-        else
-            push!(fields, KomaMRICore.f32(getfield(x, field)))
-        end
-    end
-    return KomaMRICore.ArbitraryMotion(fields...)
-end
 function Adapt.adapt_storage(
     ::MetalBackend, x::Vector{KomaMRICore.LinearInterpolator{T,V}}
 ) where {T<:Real,V<:AbstractVector{T}}

--- a/KomaMRICore/ext/KomaMetalExt.jl
+++ b/KomaMRICore/ext/KomaMetalExt.jl
@@ -9,19 +9,19 @@ KomaMRICore.set_device!(::MetalBackend, device_index::Integer) = device_index ==
 KomaMRICore.set_device!(::MetalBackend, dev::Metal.MTLDevice) = Metal.device!(dev)
 KomaMRICore.device_name(::MetalBackend) = String(Metal.current_device().name)
 
-function adapt_storage(::MetalBackend, x::ArbitraryMotion)
+function adapt_storage(::MetalBackend, x::KomaMRICore.ArbitraryMotion)
     fields = []
-    for field in fieldnames(ArbitraryMotion)
+    for field in fieldnames(KomaMRICore.ArbitraryMotion)
         if field in (:ux, :uy, :uz) 
-            push!(fields, adapt(::MetalBackend, getfield(x, field)))
+            push!(fields, adapt(MetalBackend(), getfield(x, field)))
         else
             push!(fields, f32(getfield(x, field)))
         end
     end
-    return ArbitraryMotion(fields...)
+    return KomaMRICore.ArbitraryMotion(fields...)
 end
 function adapt_storage(
-    ::MetalBackend, x::Vector{LinearInterpolator{T,V}}
+    ::MetalBackend, x::Vector{KomaMRICore.LinearInterpolator{T,V}}
 ) where {T<:Real,V<:AbstractVector{T}}
     return Metal.mtl.(x)
 end

--- a/KomaMRICore/ext/KomaoneAPIExt.jl
+++ b/KomaMRICore/ext/KomaoneAPIExt.jl
@@ -8,19 +8,19 @@ KomaMRICore.isfunctional(::oneAPIBackend) = oneAPI.functional()
 KomaMRICore.set_device!(::oneAPIBackend, val) = oneAPI.device!(val)
 KomaMRICore.device_name(::oneAPIBackend) = oneAPI.properties(oneAPI.device()).name
 
-function adapt_storage(::oneAPIBackend, x::ArbitraryMotion)
+function adapt_storage(::oneAPIBackend, x::KomaMRICore.ArbitraryMotion)
     fields = []
-    for field in fieldnames(ArbitraryMotion)
+    for field in fieldnames(KomaMRICore.ArbitraryMotion)
         if field in (:ux, :uy, :uz) 
-            push!(fields, adapt(::oneAPIBackend, getfield(x, field)))
+            push!(fields, adapt(oneAPIBackend(), getfield(x, field)))
         else
             push!(fields, f32(getfield(x, field)))
         end
     end
-    return ArbitraryMotion(fields...)
+    return KomaMRICore.ArbitraryMotion(fields...)
 end
 function adapt_storage(
-    ::oneAPIBackend, x::Vector{LinearInterpolator{T,V}}
+    ::oneAPIBackend, x::Vector{KomaMRICore.LinearInterpolator{T,V}}
 ) where {T<:Real,V<:AbstractVector{T}}
     return oneAPI.oneArray.(x)
 end

--- a/KomaMRICore/ext/KomaoneAPIExt.jl
+++ b/KomaMRICore/ext/KomaoneAPIExt.jl
@@ -9,6 +9,7 @@ KomaMRICore.isfunctional(::oneAPIBackend) = oneAPI.functional()
 KomaMRICore.set_device!(::oneAPIBackend, val) = oneAPI.device!(val)
 KomaMRICore.device_name(::oneAPIBackend) = oneAPI.properties(oneAPI.device()).name
 
+Adapt.adapt_storage(::oneAPIBackend, x::KomaMRICore.NoMotion) = KomaMRICore.NoMotion{Float32}()
 Adapt.adapt_storage(::oneAPIBackend, x::KomaMRICore.SimpleMotion) = KomaMRICore.f32(x)
 function Adapt.adapt_storage(::oneAPIBackend, x::KomaMRICore.ArbitraryMotion)
     fields = []

--- a/KomaMRICore/ext/KomaoneAPIExt.jl
+++ b/KomaMRICore/ext/KomaoneAPIExt.jl
@@ -9,23 +9,10 @@ KomaMRICore.isfunctional(::oneAPIBackend) = oneAPI.functional()
 KomaMRICore.set_device!(::oneAPIBackend, val) = oneAPI.device!(val)
 KomaMRICore.device_name(::oneAPIBackend) = oneAPI.properties(oneAPI.device()).name
 
-Adapt.adapt_storage(::oneAPIBackend, x::KomaMRICore.NoMotion) = KomaMRICore.NoMotion{Float32}()
-Adapt.adapt_storage(::oneAPIBackend, x::KomaMRICore.SimpleMotion) = KomaMRICore.f32(x)
-function Adapt.adapt_storage(::oneAPIBackend, x::KomaMRICore.ArbitraryMotion)
-    fields = []
-    for field in fieldnames(KomaMRICore.ArbitraryMotion)
-        if field in (:ux, :uy, :uz) 
-            push!(fields, Adapt.adapt(oneAPIBackend(), getfield(x, field)))
-        else
-            push!(fields, KomaMRICore.f32(getfield(x, field)))
-        end
-    end
-    return KomaMRICore.ArbitraryMotion(fields...)
-end
 function Adapt.adapt_storage(
     ::oneAPIBackend, x::Vector{KomaMRICore.LinearInterpolator{T,V}}
 ) where {T<:Real,V<:AbstractVector{T}}
-    return oneAPI.oneArray.(x)
+    return Adapt.adapt.(oneArray, a)
 end
 
 function KomaMRICore._print_devices(::oneAPIBackend)

--- a/KomaMRICore/ext/KomaoneAPIExt.jl
+++ b/KomaMRICore/ext/KomaoneAPIExt.jl
@@ -8,6 +8,23 @@ KomaMRICore.isfunctional(::oneAPIBackend) = oneAPI.functional()
 KomaMRICore.set_device!(::oneAPIBackend, val) = oneAPI.device!(val)
 KomaMRICore.device_name(::oneAPIBackend) = oneAPI.properties(oneAPI.device()).name
 
+function adapt_storage(::oneAPIBackend, x::ArbitraryMotion)
+    fields = []
+    for field in fieldnames(ArbitraryMotion)
+        if field in (:ux, :uy, :uz) 
+            push!(fields, adapt(::oneAPIBackend, getfield(x, field)))
+        else
+            push!(fields, f32(getfield(x, field)))
+        end
+    end
+    return ArbitraryMotion(fields...)
+end
+function adapt_storage(
+    ::oneAPIBackend, x::Vector{LinearInterpolator{T,V}}
+) where {T<:Real,V<:AbstractVector{T}}
+    return oneAPI.oneArray.(x)
+end
+
 function KomaMRICore._print_devices(::oneAPIBackend)
     devices = [
         Symbol("($(i-1)$(i == 1 ? "*" : " "))") => oneAPI.properties(d).name for

--- a/KomaMRICore/src/simulation/Functors.jl
+++ b/KomaMRICore/src/simulation/Functors.jl
@@ -1,14 +1,14 @@
 import Adapt: adapt, adapt_storage
 import Functors: @functor, functor, fmap, isleaf
 
-#Aux. funcitons to check if the variable we want to convert to CuArray is numeric
+#Aux. funcitons to check if the variable we want to move to the GPU is numeric
 _isleaf(x) = isleaf(x)
 _isleaf(::AbstractArray{<:Number}) = true
 _isleaf(::AbstractArray{T}) where T = isbitstype(T)
 _isleaf(::AbstractRange) = true
 
 """
-	gpu(x)
+	gpu(x, backend)
 
 Tries to move `x` to the GPU backend specified in the 'backend' parameter. 
 

--- a/KomaMRICore/src/simulation/Functors.jl
+++ b/KomaMRICore/src/simulation/Functors.jl
@@ -42,6 +42,21 @@ x = x |> cpu
 """
 cpu(x) = fmap(x -> adapt(KA.CPU(), x), x, exclude=_isleaf)
 
+#MotionModel structs
+adapt_storage(::KA.GPU, x::NoMotion) = x
+adapt_storage(::KA.GPU, x::SimpleMotion) = x
+function adapt_storage(backend::KA.GPU, xs::ArbitraryMotion)
+    fields = []
+    for field in fieldnames(ArbitraryMotion)
+        if field in (:ux, :uy, :uz)
+            push!(fields, adapt(backend, getfield(xs, field)))
+        else
+            push!(fields, getfield(xs, field))
+        end
+    end
+    return KomaMRICore.ArbitraryMotion(fields...)
+end
+
 #Precision
 paramtype(T::Type{<:Real}, m) = fmap(x -> adapt(T, x), m)
 adapt_storage(T::Type{<:Real}, xs::Real) = convert(T, xs)

--- a/KomaMRICore/src/simulation/SimulatorCore.jl
+++ b/KomaMRICore/src/simulation/SimulatorCore.jl
@@ -362,7 +362,7 @@ function simulate(
         seqd = seqd |> f64 #DiscreteSequence
         Xt   = Xt |> f64 #SpinStateRepresentation
         sig  = sig |> f64 #Signal
-    else
+    end
 
     # Simulation
     @info "Running simulation in the $(backend isa KA.GPU ? "GPU ($gpu_name)" : "CPU with $(sim_params["Nthreads"]) thread(s)")" koma_version =

--- a/KomaMRICore/src/simulation/SimulatorCore.jl
+++ b/KomaMRICore/src/simulation/SimulatorCore.jl
@@ -337,7 +337,7 @@ function simulate(
     if !KA.supports_float64(backend) && sim_params["precision"] == "f64"
         sim_params["precision"] = "f32"
         @info """ Backend: '$(name(backend))' does not support 64-bit precision 
-        floating point operations. Automatically converting to type Float32.
+        floating point operations. Simulation types will be converted to Float32.
         (set sim_param["precision"] = "f32" to avoid seeing this message).
         """ maxlog=1
     end

--- a/KomaMRICore/src/simulation/SimulatorCore.jl
+++ b/KomaMRICore/src/simulation/SimulatorCore.jl
@@ -335,7 +335,7 @@ function simulate(
     backend = get_backend(sim_params["gpu"])
     sim_params["gpu"] &= backend isa KA.GPU
     if !KA.supports_float64(backend) && sim_params["precision"] == "f64"
-        sim_params[precision] = "f32"
+        sim_params["precision"] = "f32"
         @info """ Backend: '$(name(backend))' does not support 64-bit precision 
         floating point operations. Automatically converting to type Float32.
         (set sim_param["precision"] = "f32" to avoid seeing this message).

--- a/KomaMRICore/src/simulation/SimulatorCore.jl
+++ b/KomaMRICore/src/simulation/SimulatorCore.jl
@@ -337,11 +337,16 @@ function simulate(
     if !KA.supports_float64(backend) && sim_params["precision"] == "f64"
         sim_params["precision"] = "f32"
         @info """ Backend: '$(name(backend))' does not support 64-bit precision 
-        floating point operations. Simulation types will be converted to Float32.
+        floating point operations. Automatically converting to type Float32.
         (set sim_param["precision"] = "f32" to avoid seeing this message).
         """ maxlog=1
     end
-    if sim_params["precision"] == "f32"
+    if sim_params["precision"] == "f64" && KA.supports_float64(backend)
+        obj  = obj |> f64 #Phantom
+        seqd = seqd |> f64 #DiscreteSequence
+        Xt   = Xt |> f64 #SpinStateRepresentation
+        sig  = sig |> f64 #Signal
+    else
         #Precision  #Default
         obj  = obj |> f32 #Phantom
         seqd = seqd |> f32 #DiscreteSequence
@@ -356,12 +361,6 @@ function simulate(
         seqd = gpu(seqd, backend) #DiscreteSequence
         Xt = gpu(Xt, backend) #SpinStateRepresentation
         sig = gpu(sig, backend) #Signal
-    end
-    if sim_params["precision"] == "f64" && KA.supports_float64(backend)
-        obj  = obj |> f64 #Phantom
-        seqd = seqd |> f64 #DiscreteSequence
-        Xt   = Xt |> f64 #SpinStateRepresentation
-        sig  = sig |> f64 #Signal
     end
 
     # Simulation

--- a/KomaMRICore/src/simulation/SimulatorCore.jl
+++ b/KomaMRICore/src/simulation/SimulatorCore.jl
@@ -341,6 +341,13 @@ function simulate(
         (set sim_param["precision"] = "f32" to avoid seeing this message).
         """ maxlog=1
     end
+    if sim_params["precision"] == "f32"
+        #Precision  #Default
+        obj  = obj |> f32 #Phantom
+        seqd = seqd |> f32 #DiscreteSequence
+        Xt   = Xt |> f32 #SpinStateRepresentation
+        sig  = sig |> f32 #Signal
+    end
     # Objects to GPU
     if backend isa KA.GPU
         isnothing(sim_params["gpu_device"]) || set_device!(backend, sim_params["gpu_device"])
@@ -356,12 +363,6 @@ function simulate(
         Xt   = Xt |> f64 #SpinStateRepresentation
         sig  = sig |> f64 #Signal
     else
-        #Precision  #Default
-        obj  = obj |> f32 #Phantom
-        seqd = seqd |> f32 #DiscreteSequence
-        Xt   = Xt |> f32 #SpinStateRepresentation
-        sig  = sig |> f32 #Signal
-    end
 
     # Simulation
     @info "Running simulation in the $(backend isa KA.GPU ? "GPU ($gpu_name)" : "CPU with $(sim_params["Nthreads"]) thread(s)")" koma_version =

--- a/KomaMRICore/src/simulation/SimulatorCore.jl
+++ b/KomaMRICore/src/simulation/SimulatorCore.jl
@@ -341,6 +341,15 @@ function simulate(
         (set sim_param["precision"] = "f32" to avoid seeing this message).
         """ maxlog=1
     end
+    # Objects to GPU
+    if backend isa KA.GPU
+        isnothing(sim_params["gpu_device"]) || set_device!(backend, sim_params["gpu_device"])
+        gpu_name = device_name(backend)
+        obj = gpu(obj, backend) #Phantom
+        seqd = gpu(seqd, backend) #DiscreteSequence
+        Xt = gpu(Xt, backend) #SpinStateRepresentation
+        sig = gpu(sig, backend) #Signal
+    end
     if sim_params["precision"] == "f64" && KA.supports_float64(backend)
         obj  = obj |> f64 #Phantom
         seqd = seqd |> f64 #DiscreteSequence
@@ -352,15 +361,6 @@ function simulate(
         seqd = seqd |> f32 #DiscreteSequence
         Xt   = Xt |> f32 #SpinStateRepresentation
         sig  = sig |> f32 #Signal
-    end
-    # Objects to GPU
-    if backend isa KA.GPU
-        isnothing(sim_params["gpu_device"]) || set_device!(backend, sim_params["gpu_device"])
-        gpu_name = device_name(backend)
-        obj = gpu(obj, backend) #Phantom
-        seqd = gpu(seqd, backend) #DiscreteSequence
-        Xt = gpu(Xt, backend) #SpinStateRepresentation
-        sig = gpu(sig, backend) #Signal
     end
 
     # Simulation

--- a/KomaMRICore/test/runtests.jl
+++ b/KomaMRICore/test/runtests.jl
@@ -548,7 +548,7 @@ end
         "return_type"=>"mat", 
         "precision"=>"f64"
     )
-    sig = simulate(obj, seq, sys; sim_params)
+    sig = @suppress simulate(obj, seq, sys; sim_params)
     sig = sig / prod(size(obj))
     NMRSE(x, x_true) = sqrt.( sum(abs.(x .- x_true).^2) ./ sum(abs.(x_true).^2) ) * 100.
     @test NMRSE(sig, sig_jemris) < 1 #NMRSE < 1%

--- a/KomaMRICore/test/runtests.jl
+++ b/KomaMRICore/test/runtests.jl
@@ -548,7 +548,7 @@ end
         "return_type"=>"mat", 
         "precision"=>"f64"
     )
-    sig = @suppress simulate(obj, seq, sys; sim_params)
+    sig = simulate(obj, seq, sys; sim_params)
     sig = sig / prod(size(obj))
     NMRSE(x, x_true) = sqrt.( sum(abs.(x .- x_true).^2) ./ sum(abs.(x_true).^2) ) * 100.
     @test NMRSE(sig, sig_jemris) < 1 #NMRSE < 1%


### PR DESCRIPTION
There are a few issues with https://github.com/JuliaHealth/KomaMRI.jl/pull/405 I noticed while running tests today. I forgot about the :skipci tag test filter, so I was only running the CPU tests while testing KomaMRICore. It turns out the GPU SimpleMotion and ArbitraryMotion tests were failing as a result of doing away with the custom adapt_storage definitions. However, after adding back the equivalent adapt_storage functions in KomaMetalExt and KomaCUDAExt, these tests pass once again. The other issue was in line 338 in SimulatorCore.jl:

sim_params[precision]

should be:

sim_params["precision"]

Also fixed in this pull request. So with these changes, all 85 of the KomaMRICore tests pass when using CUDA and Metal (still not sure about AMD / oneAPI until #147 ) 