### PR TITLE
Fix typos in docstrings

### DIFF
--- a/KomaMRIBase/src/datatypes/phantom/motion/ArbitraryMotion.jl
+++ b/KomaMRIBase/src/datatypes/phantom/motion/ArbitraryMotion.jl
@@ -22,24 +22,24 @@ const Interpolator2D = Interpolations.GriddedInterpolation{
 }
 
 """
-    motion = ArbitraryMotion(period_durations, dx, dy, dz)
+    motion = ArbitraryMotion(t_start, t_end, dx, dy, dz)
 
 ArbitraryMotion model. For this motion model, it is necessary to define 
 motion for each spin independently, in x (`dx`), y (`dy`) and z (`dz`).
 `dx`, `dy` and `dz` are three matrixes, of (``N_{spins}`` x ``N_{discrete\\,times}``) each.
 This means that each row corresponds to a spin trajectory over a set of discrete time instants.
-`period_durations` is a vector that contains the period for periodic (one element) or 
-pseudo-periodic (two or more elements) motion.
-The discrete time instants are calculated diving `period_durations` by ``N_{discrete\\,times}``.
+The duration of the movement is determined by `t_start` and `t_end`
+The discrete time instants are evenly spaced, (``dt = \frac{t_{end} - t_{start}}{N_{discrete\\,times}}``). 
 
 This motion model is useful for defining arbitrarly complex motion, specially
 for importing the spin trajectories from another source, like XCAT or a CFD.
 
 # Arguments
-- `period_durations`: (`Vector{T}`) 
-- `dx`: (`::Array{T,2}`) matrix for displacements in x
-- `dy`: (`::Array{T,2}`) matrix for displacements in y
-- `dz`: (`::Array{T,2}`) matrix for displacements in z
+- `t_start`: (`::T`, `[s]`) 
+- `t_end`: (`::T`, `[s]`) 
+- `dx`: (`::Array{T,2}`, `[m]`) matrix for displacements in x
+- `dy`: (`::Array{T,2}`, `[m]`) matrix for displacements in y
+- `dz`: (`::Array{T,2}`, `[m]`) matrix for displacements in z
 
 # Returns
 - `motion`: (`::ArbitraryMotion`) ArbitraryMotion struct
@@ -47,7 +47,8 @@ for importing the spin trajectories from another source, like XCAT or a CFD.
 # Examples
 ```julia-repl
 julia> motion = ArbitraryMotion(
-            [1.0], 
+            0.0,
+            1.0, 
             0.01.*rand(1000, 10), 
             0.01.*rand(1000, 10), 
             0.01.*rand(1000, 10)

--- a/KomaMRIBase/src/datatypes/phantom/motion/ArbitraryMotion.jl
+++ b/KomaMRIBase/src/datatypes/phantom/motion/ArbitraryMotion.jl
@@ -28,7 +28,7 @@ ArbitraryMotion model. For this motion model, it is necessary to define
 motion for each spin independently, in x (`dx`), y (`dy`) and z (`dz`).
 `dx`, `dy` and `dz` are three matrixes, of (``N_{spins}`` x ``N_{discrete\\,times}``) each.
 This means that each row corresponds to a spin trajectory over a set of discrete time instants.
-The duration of the movement is determined by `t_start` and `t_end`
+The motion duration is determined by `t_start` and `t_end`.
 The discrete time instants are evenly spaced, (``dt = \frac{t_{end} - t_{start}}{N_{discrete\\,times}}``). 
 
 This motion model is useful for defining arbitrarly complex motion, specially

--- a/KomaMRIBase/src/datatypes/phantom/motion/SimpleMotion.jl
+++ b/KomaMRIBase/src/datatypes/phantom/motion/SimpleMotion.jl
@@ -12,7 +12,7 @@ which is a tuple of simple motion types. This tuple will contain as many element
 as simple motions we want to combine.
 
 # Arguments
-- `types`: (`::Tuple{Vararg{<:SimpleMotionType{T}}}`) vector of simple motion types
+- `types`: (`::Tuple{Vararg{<:SimpleMotionType{T}}}`) tuple of simple motion types
 
 # Returns
 - `motion`: (`::SimpleMotion`) SimpleMotion struct


### PR DESCRIPTION
Fix some typos in docstrings that I forgot to change in #408 