### PR TITLE
Trapezoidal rule for RFs

### DIFF
--- a/KomaMRIBase/src/datatypes/simulation/DiscreteSequence.jl
+++ b/KomaMRIBase/src/datatypes/simulation/DiscreteSequence.jl
@@ -27,8 +27,6 @@ struct DiscreteSequence{T<:Real}
     t::AbstractVector{T}
     Δt::AbstractVector{T}
 end
-
-Base.length(seq::DiscreteSequence) = length(seq.Δt)
 Base.getindex(seq::DiscreteSequence, i::Integer) = begin
     DiscreteSequence(seq.Gx[i, :],
                      seq.Gy[i, :],
@@ -39,35 +37,34 @@ Base.getindex(seq::DiscreteSequence, i::Integer) = begin
                      seq.t[i, :],
                      seq.Δt[i, :])
 end
+# Use in precession trapezoidal rule
 Base.getindex(seq::DiscreteSequence, i::UnitRange) = begin
-    DiscreteSequence(seq.Gx[i.start:i.stop+1],
-                     seq.Gy[i.start:i.stop+1],
-                     seq.Gz[i.start:i.stop+1],
-                     seq.B1[i.start:i.stop+1],
-                     seq.Δf[i.start:i.stop+1],
+    DiscreteSequence(seq.Gx[i],
+                     seq.Gy[i],
+                     seq.Gz[i],
+                     seq.B1[i],
+                     seq.Δf[i],
                      seq.ADC[i],
-                     seq.t[i.start:i.stop+1],
-                     seq.Δt[i])
+                     seq.t[i],
+                     seq.Δt[i.start:i.stop-1])
 end
 Base.view(seq::DiscreteSequence, i::UnitRange) = begin
-    @views DiscreteSequence(seq.Gx[i.start:i.stop+1],
-                     seq.Gy[i.start:i.stop+1],
-                     seq.Gz[i.start:i.stop+1],
-                     seq.B1[i.start:i.stop+1],
-                     seq.Δf[i.start:i.stop+1],
+    @views DiscreteSequence(seq.Gx[i],
+                     seq.Gy[i],
+                     seq.Gz[i],
+                     seq.B1[i],
+                     seq.Δf[i],
                      seq.ADC[i],
-                     seq.t[i.start:i.stop+1],
-                     seq.Δt[i])
+                     seq.t[i],
+                     seq.Δt[i.start:i.stop-1])
 end
+Base.length(seq::DiscreteSequence)  = length(seq.Δt)
 Base.iterate(seq::DiscreteSequence) = (seq[1], 2)
 Base.iterate(seq::DiscreteSequence, i) = (i <= length(seq)) ? (seq[i], i+1) : nothing
 
-is_GR_on(seq::DiscreteSequence) =  sum(abs.([seq.Gx[1:end-1]; seq.Gy[1:end-1]; seq.Gz[1:end-1]])) != 0
-is_RF_on(seq::DiscreteSequence) =  sum(abs.(seq.B1[1:end-1])) != 0
-is_ADC_on(seq::DiscreteSequence) = sum(abs.(seq.ADC[1:end-1])) != 0
-is_GR_off(seq::DiscreteSequence) =  !is_GR_on(seq)
-is_RF_off(seq::DiscreteSequence) =  !is_RF_on(seq)
-is_ADC_off(seq::DiscreteSequence) = !is_ADC_on(seq)
+is_GR_on(seq::DiscreteSequence)   = sum(abs.([seq.Gx; seq.Gy; seq.Gz])) != 0
+is_RF_on(seq::DiscreteSequence)   = sum(abs.(seq.B1)) != 0
+is_ADC_on(seq::DiscreteSequence)  = sum(abs.(seq.ADC)) != 0
 
 """
     seqd = discretize(seq::Sequence; sampling_params=default_sampling_params())

--- a/KomaMRICore/src/datatypes/VectorSU2.jl
+++ b/KomaMRICore/src/datatypes/VectorSU2.jl
@@ -1,0 +1,24 @@
+mutable struct VectorSU2{T}
+    xy::AbstractVector{Complex{T}}
+    z::AbstractVector{T}
+end
+
+# Required indexing operations
+Base.view(V::VectorSU2, i::UnitRange) = @views VectorSU2(V.xy[i], V.z[i])
+
+# Maths
+Base.abs(V::VectorSU2) = sqrt.(abs.(V.xy).^2 + (V.z).^2)
+Base.:/(V::VectorSU2, α) = VectorSU2(V.xy/α, V.z/α)
+Base.:+(V1::VectorSU2, V2::VectorSU2) = VectorSU2(V1.xy .+ V2.xy, V1.z .+ V2.z)
+
+# Definition of Spinor from VectorSU2
+function calculateRot!(pre::PreallocResult{T}, Δt::T) where {T}
+    # Beff = pre.B_new
+    Beff = (pre.B_old + pre.B_new) / 2
+    absBeff = abs(Beff)
+    # absBeff[absBeff .== zero(T)] .= eps(T) # not sure why this is needed, in RF block this should be non-zero
+    @. pre.φ = T(-2π * γ) * absBeff * Δt 
+    @. pre.Rot.α = cos(pre.φ/2) - Complex{T}(im) * (Beff.z / absBeff) * sin(pre.φ/2)
+    @. pre.Rot.β = -Complex{T}(im) * (Beff.xy / absBeff) * sin(pre.φ/2)
+    return nothing
+end

--- a/KomaMRICore/src/simulation/SimMethods/SimulationMethod.jl
+++ b/KomaMRICore/src/simulation/SimMethods/SimulationMethod.jl
@@ -2,7 +2,6 @@
 struct Bloch <: SimulationMethod end
 
 export Bloch
-
 include("Magnetization.jl")
 
 @functor Mag #Gives gpu acceleration capabilities, see GPUFunctions.jl
@@ -34,6 +33,7 @@ Base.view(p::DefaultPreAlloc, i::UnitRange) = p
 """Default preallocation function."""
 prealloc(sim_method::SimulationMethod, backend::KA.Backend, obj::Phantom{T}, M::Mag{T}) where {T<:Real} = DefaultPreAlloc{T}()
 
+include("../../datatypes/VectorSU2.jl")
 include("KernelFunctions.jl")
 include("BlochSimple/BlochSimple.jl")
 include("Bloch/BlochCPU.jl")


### PR DESCRIPTION
In this PR I want to:
- Fix how RF blocks are determined, to properly consider step-wise linear B1(t) fields (consider RF block from t0+delay to t0+dur, instead of relying on when the RFs are 0, as that can generate some bugs like in -> B1=^^)
- Enable negative delays, and MRIEvents's duration to be greater than one block
- Clean current code using PreAlloc's to have a physical meaning
- Test accuracy of new RF simulation
 