### PR TITLE
Optimize run_spin_excitation! for GPU

### DIFF
--- a/KomaMRICore/src/simulation/SimMethods/Bloch/BlochGPU.jl
+++ b/KomaMRICore/src/simulation/SimMethods/Bloch/BlochGPU.jl
@@ -181,7 +181,6 @@ function run_spin_excitation!(
     #Effective Field
     pre.Bz .= (x .* seq.Gx' .+ y .* seq.Gy' .+ z .* seq.Gz') .+ pre.ΔBz .- seq.Δf' ./ T(γ) # ΔB_0 = (B_0 - ω_rf/γ), Need to add a component here to model scanner's dB0(x,y,z)
     pre.B .= sqrt.(abs.(seq.B1') .^ 2 .+ abs.(pre.Bz) .^ 2)
-    pre.B[pre.B .== 0] .= eps(T)
     
     #Spinor Rotation
     pre.φ .= T(-π .* γ) .* (pre.B[:,1:end-1] .* seq.Δt') # TODO: Use trapezoidal integration here (?),  this is just Forward Euler

--- a/KomaMRICore/src/simulation/SimMethods/Bloch/BlochGPU.jl
+++ b/KomaMRICore/src/simulation/SimMethods/Bloch/BlochGPU.jl
@@ -68,8 +68,6 @@ struct BlochGPUPrealloc{T} <: PreallocResult{T}
     Bz::AbstractMatrix{T}
     B::AbstractMatrix{T}
     φ::AbstractMatrix{T}
-    nxy::AbstractMatrix{T}
-    nz::AbstractMatrix{T}
     ΔT1::AbstractMatrix{T}
     ΔT2::AbstractMatrix{T}
     Δϕ::AbstractMatrix{T}
@@ -87,8 +85,6 @@ function prealloc_block(p::BlochGPUPrealloc{T}, i::Integer) where {T<:Real}
         view(p.Bz,:,1:seq_block.length),
         view(p.B,:,1:seq_block.length),
         view(p.φ,:,1:seq_block.length-1),
-        view(p.nxy,:,1:seq_block.length),
-        view(p.nz,:,1:seq_block.length),
         view(p.ΔT1,:,1:seq_block.length-1),
         view(p.ΔT2,:,1:seq_block.length-1),
         view(p.Δϕ,:,1:seq_block.length-1),
@@ -107,8 +103,6 @@ function prealloc(sim_method::Bloch, backend::KA.GPU, obj::Phantom{T}, M::Mag{T}
         KA.zeros(backend, T, (size(obj.x, 1), max_block_length)),
         KA.zeros(backend, T, (size(obj.x, 1), max_block_length)),
         KA.zeros(backend, T, (size(obj.x, 1), max_block_length-1)),
-        KA.zeros(backend, T, (size(obj.x, 1), max_block_length)),
-        KA.zeros(backend, T, (size(obj.x, 1), max_block_length)),
         KA.zeros(backend, T, (size(obj.x, 1), max_block_length-1)),
         KA.zeros(backend, T, (size(obj.x, 1), max_block_length-1)),
         KA.zeros(backend, T, (size(obj.x, 1), max_block_length-1)),
@@ -170,7 +164,7 @@ function run_spin_precession!(
     M.xy .= M.xy .* exp.(-seq_block.dur ./ p.T2) .* _cis.(pre.ϕ[:,end])
 
     return nothing
-end 
+end
 
 function run_spin_excitation!(
     p::Phantom{T},
@@ -188,41 +182,17 @@ function run_spin_excitation!(
     pre.Bz .= (x .* seq.Gx' .+ y .* seq.Gy' .+ z .* seq.Gz') .+ pre.ΔBz .- seq.Δf' ./ T(γ) # ΔB_0 = (B_0 - ω_rf/γ), Need to add a component here to model scanner's dB0(x,y,z)
     pre.B .= sqrt.(abs.(seq.B1') .^ 2 .+ abs.(pre.Bz) .^ 2)
     pre.B[pre.B .== 0] .= eps(T)
-    pre.φ .= T(-2π .* γ) .* (pre.B[:,1:end-1] .* seq.Δt')
-    pre.nxy .= seq.B1' ./ pre.B
-    pre.nz .= pre.Bz ./ pre.B
-    pre.ΔT1 .= seq.Δt' ./ p.T1
-    pre.ΔT2 .= seq.Δt' ./ p.T2
+    
+    #Spinor Rotation
+    pre.φ .= T(-π .* γ) .* (pre.B[:,1:end-1] .* seq.Δt') # TODO: Use trapezoidal integration here (?),  this is just Forward Euler
+    
+    #Relaxation
+    pre.ΔT1 .= exp.(-seq.Δt' ./ p.T1)
+    pre.ΔT2 .= exp.(-seq.Δt' ./ p.T2)
 
-    Mxy = similar(M.xy)
-    Mz = similar(M.z)
-    α = similar(M.xy)
-    β = similar(M.xy)
-    apply_excitation!(backend, 256)(α, β, Mxy, Mz, M.xy, M.z, pre.Bz, pre.B, pre.φ, pre.nxy, pre.nz, pre.ΔT1, pre.ΔT2, p.ρ; ndrange=size(M.xy,1))
+    #Excitation
+    apply_excitation!(backend, 512)(M.xy, M.z, pre.φ, seq.B1, pre.Bz, pre.B, pre.ΔT1, pre.ΔT2, p.ρ, ndrange=size(M.xy,1))
     KA.synchronize(backend)
 
-    #=
-    #Simulation
-    count = 0
-    for s in seq #This iterates over seq, "s = seq[i,:]"
-        count += 1
-        #Motion
-        x, y, z = get_spin_coords(p.motion, p.x, p.y, p.z, s.t)
-        #Effective field
-        ΔBz = p.Δw ./ T(2π .* γ) .- s.Δf ./ T(γ) # ΔB_0 = (B_0 - ω_rf/γ), Need to add a component here to model scanner's dB0(x,y,z)
-        Bz = (s.Gx .* x .+ s.Gy .* y .+ s.Gz .* z) .+ ΔBz
-        B = sqrt.(abs.(s.B1) .^ 2 .+ abs.(Bz) .^ 2)
-        B[B .== 0] .= eps(T)
-        #Spinor Rotation
-        φ = T(-2π .* γ) .* (B .* s.Δt) # TODO: Use trapezoidal integration here (?),  this is just Forward Euler
-        mul!(Q(φ, s.B1 ./ B, Bz ./ B), M)
-        #Relaxation
-        tmp = -s.Δt ./ p.T1
-        M.xy .= M.xy .* exp.(-s.Δt ./ p.T2)
-        M.z .= M.z .* exp.(-s.Δt ./ p.T1) .+ p.ρ .* (1 .- exp.(-s.Δt ./ p.T1))
-    end
-    =#
-    #Acquired signal
-    #sig .= -1.4im #<-- This was to test if an ADC point was inside an RF block
     return nothing
 end

--- a/KomaMRICore/src/simulation/SimMethods/Bloch/KernelFunctions.jl
+++ b/KomaMRICore/src/simulation/SimMethods/Bloch/KernelFunctions.jl
@@ -1,5 +1,7 @@
 using KernelAbstractions: @kernel, @Const, @index, @uniform, @groupsize, @localmem
 
+## COV_EXCL_START
+
 @kernel function apply_excitation!(Mxy, Mz, @Const(φ), @Const(B1), @Const(Bz), @Const(B), @Const(ΔT1), @Const(ΔT2), @Const(ρ))
     i_g = @index(Global)
     i_l = @index(Local)
@@ -49,3 +51,5 @@ using KernelAbstractions: @kernel, @Const, @index, @uniform, @groupsize, @localm
     @inbounds Mxy[i_g] = s_Mxy_r[i_l] + 1im * s_Mxy_i[i_l]
     @inbounds Mz[i_g] = s_Mz[i_l]
 end
+
+## COV_EXCL_STOP

--- a/KomaMRICore/src/simulation/SimMethods/Bloch/KernelFunctions.jl
+++ b/KomaMRICore/src/simulation/SimMethods/Bloch/KernelFunctions.jl
@@ -1,0 +1,44 @@
+using KernelAbstractions: @kernel, @Const, @index, @uniform, @groupsize, @localmem
+
+#=
+macro myunroll(N)
+    exp = []
+    var1 = esc(quote
+        for t=1:$N
+            β[i_g] = -im * nxy[i_g, t] * sin(φ[i_g, t] / 2)
+        end
+    end)
+    return var1
+    push!(exp, var1)
+    return esc(quote
+        $exp[1]
+        $exp[2]
+    end)
+end
+=#
+
+@kernel function apply_excitation!(α, β, Mxy_tmp, Mz_tmp, Mxy, Mz, Bz, B, φ, nxy, nz, ΔT1, ΔT2, ρ)
+    i_g = @index(Global)
+    #i_l = @index(Local)
+
+    T = eltype(Bz)
+    #@uniform N = @groupsize()[1]
+    #@uniform N_Δt = size(φ, 2)
+
+    #s_α = @localmem Complex{T} (N,)
+    #s_β = @localmem Complex{T} (N,)
+    #s_Mxy_tmp = @localmem Complex{T} (N,)
+    #s_Mz_tmp = @localmem T (N,)
+
+    N = size(φ, 2)
+    #KA.Extras.LoopInfo.@unroll 
+    @inbounds for t=1:N
+        α[i_g] = cos(φ[i_g, t] / 2) - 1im * nz[i_g, t] * sin(φ[i_g, t] / 2)
+        β[i_g] = -im * nxy[i_g, t] * sin(φ[i_g, t] / 2)
+        Mxy_tmp[i_g] = 2 * conj(α[i_g]) * β[i_g] * Mz[i_g] + conj(α[i_g])^2 * Mxy[i_g] - β[i_g]^2 * conj(Mxy[i_g])
+        Mz_tmp[i_g] = (abs(α[i_g])^2 - abs(β[i_g])^2) * Mz[i_g] - 2 * real(α[i_g] * β[i_g] * conj(Mxy[i_g]))
+        Mxy[i_g] = Mxy_tmp[i_g] * exp(-ΔT2[i_g, t])
+        Mz[i_g] = Mz_tmp[i_g] * exp(-ΔT1[i_g, t]) + ρ[i_g] * (1 - exp(-ΔT1[i_g, t]))
+    end
+    #@myunroll n
+end

--- a/KomaMRICore/src/simulation/SimulatorCore.jl
+++ b/KomaMRICore/src/simulation/SimulatorCore.jl
@@ -332,9 +332,7 @@ function simulate(
     sim_params = default_sim_params(sim_params)
     #Warn if user is trying to run on CPU without enabling multi-threading
     if (!sim_params["gpu"] && Threads.nthreads() == 1)
-        @info """
-            Simulation will be run on the CPU with only 1 thread. To
-            enable multi-threading, start julia with --threads=auto.
+        @info """Simulation will be run on the CPU with only 1 thread. To enable multi-threading, start julia with --threads=auto
         """ maxlog=1
     end
     # Simulation init


### PR DESCRIPTION
This pull request adds a GPU-optimized implementation of run_spin_excitation! to BlochGPU.jl. Compared with the function in BlochSimple.jl, the calculations which can be done beforehand for all time points are stored in preallocated matrices Bz, B, φ, ΔT1, and ΔT2. The sequential calculations are done inside a kernel apply_excitation!, which uses shared memory for all repeated memory accesses, and does the real / imaginary number math in Magnetization.jl directly so that the shared memory arrays store successive 32-bit values, which I think is ideal to avoid bank conflicts (https://developer.nvidia.com/blog/using-shared-memory-cuda-cc/).

The tests pass for Metal on my computer, and I've seen the excitation-heavy MRI Lab benchmark speed up by ~5x. Hopefully the same will be true for the other backends!