### PR TITLE
Time Comparison

### DIFF
--- a/KomaMRICore/src/KomaMRICore.jl
+++ b/KomaMRICore/src/KomaMRICore.jl
@@ -19,7 +19,7 @@ include("other/DiffusionModel.jl")
 # Simulator
 include("simulation/GPUFunctions.jl")
 include("simulation/Functors.jl")
-include("simulation/SimulatorCore.jl")
+include("simulation/SimulatorCore.jl") 
 
 # ISMRMRD
 export signal_to_raw_data


### PR DESCRIPTION
As suggested by @cncastillo, I'm submitting a pull request reverting the repository to the first commit where the benchmarking CI was running (https://github.com/JuliaHealth/KomaMRI.jl/commit/5b6e9fbbda2311e57f3988185f1d3b13eefe3da1) so we can get an official time comparison by running the benchmarks again. We're curious if the AMD time improvements seen after (https://github.com/JuliaHealth/KomaMRI.jl/commit/1457a4c3ae1e3e7cc40819c534d8c36620bccb75) are actually due to the changes in that commit or an AMD change. 