### PR TITLE
Fix bug in `plot_phantom_map` when `length(obj)` > `max_spins`

### DIFF
--- a/KomaMRIPlots/src/ui/DisplayFunctions.jl
+++ b/KomaMRIPlots/src/ui/DisplayFunctions.jl
@@ -1001,6 +1001,10 @@ Plots a phantom map for a specific spin parameter given by `key`.
 - `darkmode`: (`::Bool`, `=false`) boolean to indicate whether to display darkmode style
 - `view_2d`: (`::Bool`, `=false`) boolean to indicate whether to use a 2D scatter plot
 - `colorbar`: (`::Bool`, `=true`) boolean to indicate whether to display a colorbar
+- `max_spins`:(`::Int`, `=100_000`) maximum number of displayed spins
+- `intermediate_time_samples`:(`::Int`, `=0`) intermediate time samples between motion `t_start` and `t_end`
+- `max_time_samples`:(`::Int`, `=100`) maximum number of time samples
+- `frame_duration_ms`:(`::Int`, `=250`) time in miliseconds between two frames 
 
 # Returns
 - `p`: (`::PlotlyJS.SyncPlot`) plot of the phantom map for a specific spin parameter
@@ -1124,8 +1128,8 @@ function plot_phantom_map(
     cmin_key = get(kwargs, :cmin, factor * cmin_key)
     cmax_key = get(kwargs, :cmax, factor * cmax_key)
 
-    t = process_times(m)
-    x, y, z = get_spin_coords(m, obj.x, obj.y, obj.z, t')
+    t = process_times(obj.motion)
+    x, y, z = get_spin_coords(obj.motion, obj.x, obj.y, obj.z, t')
 
     x0 = -maximum(abs.([x y z])) * 1e2
     xf = maximum(abs.([x y z])) * 1e2

--- a/KomaMRIPlots/test/GUI_PlotlyJS_backend_test.jl
+++ b/KomaMRIPlots/test/GUI_PlotlyJS_backend_test.jl
@@ -41,7 +41,7 @@
         ph.motion = MotionList(Translate(0.1, 0.1, 0.1, TimeRange(0.0, 1.0), SpinRange(1:1000)))
 
         @testset "plot_motion_phantom_map_rho" begin
-            plot_phantom_map(ph, :ρ, width=800, height=600) #Plotting the phantom's rho map
+            plot_phantom_map(ph, :ρ, width=800, height=600, max_spins=1_000) #Plotting the phantom's rho map (set max_spins=1_000)
             @test true                #If the previous line fails the test will fail
         end
 


### PR DESCRIPTION
I discovered this testing with big phantoms. I caused this error when dispatching `plot_phantom_map` for static and dynamic phantoms. 
I also add the description of some missing keyword arguments in the docstring