### PR TITLE
Fix sum of `Grad`s

### DIFF
--- a/KomaMRIBase/src/datatypes/sequence/Grad.jl
+++ b/KomaMRIBase/src/datatypes/sequence/Grad.jl
@@ -226,12 +226,12 @@ Base.zero(::Type{Grad}) = Grad(0.0, 0.0)
 # Rotation
 Base.zero(::Grad) = Grad(0.0, 0.0)
 *(α::Real, x::Grad) = Grad(α * x.A, x.T, x.rise, x.fall, x.delay)
-+(x::Grad, y::Grad) = Grad(x.A .+ y.A, x.T, x.rise, x.fall, x.delay)
++(x::Grad, y::Grad) = Grad(x.A .+ y.A, max(x.T, y.T), max(x.rise, y.rise), max(x.fall, y.fall), max(x.delay, y.delay)) 
 # Others
 *(x::Grad, α::Real) = Grad(α * x.A, x.T, x.rise, x.fall, x.delay)
 /(x::Grad, α::Real) = Grad(x.A / α, x.T, x.rise, x.fall, x.delay)
 -(x::Grad) = -1 * x
--(x::Grad, y::Grad) = Grad(x.A .- y.A, x.T, x.rise, x.fall, x.delay)
+-(x::Grad, y::Grad) = Grad(x.A .- y.A, max(x.T, y.T), max(x.rise, y.rise), max(x.fall, y.fall), max(x.delay, y.delay))
 
 # Gradient functions
 function vcat(x::Array{Grad,1}, y::Array{Grad,1})

--- a/KomaMRIBase/src/datatypes/sequence/Grad.jl
+++ b/KomaMRIBase/src/datatypes/sequence/Grad.jl
@@ -226,12 +226,12 @@ Base.zero(::Type{Grad}) = Grad(0.0, 0.0)
 # Rotation
 Base.zero(::Grad) = Grad(0.0, 0.0)
 *(α::Real, x::Grad) = Grad(α * x.A, x.T, x.rise, x.fall, x.delay)
-+(x::Grad, y::Grad) = Grad(x.A .+ y.A, max(x.T, y.T), max(x.rise, y.rise), max(x.fall, y.fall), max(x.delay, y.delay)) 
++(x::Grad, y::Grad) = Grad(x.A .+ y.A, max(x.T, y.T), max(x.rise, y.rise), max(x.fall, y.fall), max(x.delay, y.delay)) #TODO: solve this in a better way (by "stacking" gradients) issue #487
 # Others
 *(x::Grad, α::Real) = Grad(α * x.A, x.T, x.rise, x.fall, x.delay)
 /(x::Grad, α::Real) = Grad(x.A / α, x.T, x.rise, x.fall, x.delay)
 -(x::Grad) = -1 * x
--(x::Grad, y::Grad) = Grad(x.A .- y.A, max(x.T, y.T), max(x.rise, y.rise), max(x.fall, y.fall), max(x.delay, y.delay))
+-(x::Grad, y::Grad) = Grad(x.A .- y.A, max(x.T, y.T), max(x.rise, y.rise), max(x.fall, y.fall), max(x.delay, y.delay)) #TODO: solve this in a better way (by "stacking" gradients) issue #487
 
 # Gradient functions
 function vcat(x::Array{Grad,1}, y::Array{Grad,1})

--- a/KomaMRIBase/test/runtests.jl
+++ b/KomaMRIBase/test/runtests.jl
@@ -34,7 +34,11 @@ using TestItems, TestItemRunner
         R = rotz(θ)
         s2 = R*s #Matrix-Matrix{Grad} multiplication
         GR2 = R*s.GR.A #Matrix-vector multiplication
-        @test s2.GR.A ≈ GR2
+        @test s2.GR.A    ≈ GR2
+        @test s.GR.T     == s2.GR.T
+        @test s.GR.delay == s2.GR.delay
+        @test s.GR.rise  == s2.GR.rise
+        @test s.GR.fall  == s2.GR.fall
         # Rotation 3D case
         T, t1, t2, t3 = rand(4)
         N = 100
@@ -47,8 +51,11 @@ using TestItems, TestItemRunner
         R = Rx*Ry*Rz
         s2 = R*s #Matrix-Matrix{Grad} multiplication
         GR2 = R*s.GR.A #Matrix-vector multiplication
-        @test s2.GR.A ≈ GR2
-
+        @test s2.GR.A    ≈ GR2
+        @test s.GR.T     == s2.GR.T
+        @test s.GR.delay == s2.GR.delay
+        @test s.GR.rise  == s2.GR.rise
+        @test s.GR.fall  == s2.GR.fall
         # Concatenation of sequences
         A1, A2, A3, T1 = rand(4)
         s1 = Sequence([Grad(A1,T1);


### PR DESCRIPTION
This is a temporary change to solve a bug when rotating sequences:

```julia-repl
julia> using KomaMRI
julia> seq = PulseDesigner.EPI_example()
julia> plot_seq(seq[1:10])
```
![image](https://github.com/user-attachments/assets/b5d83ea5-e5de-4378-8e14-4a7dc4c57fad)

```julia-repl
julia> seq_r = rotz(π/2) * seq
julia> plot_seq(seq_r[1:10])
```
![image](https://github.com/user-attachments/assets/cb489e4c-26eb-4942-89e8-5a3a3e7a0fe9)

This bug happens when rotating a `Sequence`, as we are implicitly calling `+(Grad(0, 0), Grad(A, T))`, and this function assigns the `T`, `delay`, `rise` and `fall` of the first `Grad` to the result. A temporary solution is to assign the maximum of each one of these values:
```julia
+(x::Grad, y::Grad) = Grad(x.A .+ y.A, max(x.T, y.T), max(x.rise, y.rise), max(x.fall, y.fall), max(x.delay, y.delay)) 
```

But a better solution would be to "stack" the gradients if they have different time-related parameters. See https://github.com/JuliaHealth/KomaMRI.jl/issues/487