### PR TITLE
Avoid GPU runners for CPU jobs, and fix hanging CPU tests

### DIFF
--- a/.buildkite/runbenchmarks.yml
+++ b/.buildkite/runbenchmarks.yml
@@ -27,6 +27,7 @@ steps:
         agents:
           arch: "aarch64"
           queue: "juliaecosystem"
+          num_cpus: "4"
         env:
           BENCHMARK_GROUP: CPU
           JULIA_NUM_THREADS: "{{matrix.threads}}"

--- a/.buildkite/runbenchmarks.yml
+++ b/.buildkite/runbenchmarks.yml
@@ -30,7 +30,7 @@ steps:
         env:
           BENCHMARK_GROUP: CPU
           JULIA_NUM_THREADS: "{{matrix.threads}}"
-        timeout_in_minutes: 15
+        timeout_in_minutes: 30
 
       - label: "AMDGPU: Run Benchmarks"
         plugins:

--- a/.buildkite/runbenchmarks.yml
+++ b/.buildkite/runbenchmarks.yml
@@ -25,11 +25,11 @@ steps:
         artifact_paths: 
           - "benchmarks/results/*"
         agents:
-          queue: "benchmark"
+          queue: "juliaecosystem"
         env:
           BENCHMARK_GROUP: CPU
           JULIA_NUM_THREADS: "{{matrix.threads}}"
-        timeout_in_minutes: 120
+        timeout_in_minutes: 10
 
       - label: "AMDGPU: Run Benchmarks"
         plugins:
@@ -57,7 +57,7 @@ steps:
           rocmgpu: "gfx1101"
         env:
           BENCHMARK_GROUP: AMDGPU
-        timeout_in_minutes: 120
+        timeout_in_minutes: 30
 
       - label: "CUDA: Run Benchmarks"
         plugins:
@@ -85,7 +85,7 @@ steps:
           cuda: "*"
         env:
           BENCHMARK_GROUP: CUDA
-        timeout_in_minutes: 120
+        timeout_in_minutes: 30
 
       - label: "Metal: Run Benchmarks"
         plugins:
@@ -113,7 +113,7 @@ steps:
           arch: "aarch64"
         env:
           BENCHMARK_GROUP: Metal
-        timeout_in_minutes: 120
+        timeout_in_minutes: 30
 
       - label: "oneAPI: Run Benchmarks"
         plugins:
@@ -140,7 +140,7 @@ steps:
           intel: "*"
         env:
           BENCHMARK_GROUP: oneAPI
-        timeout_in_minutes: 120
+        timeout_in_minutes: 30
 
       - wait: ~
 

--- a/.buildkite/runbenchmarks.yml
+++ b/.buildkite/runbenchmarks.yml
@@ -25,11 +25,12 @@ steps:
         artifact_paths: 
           - "benchmarks/results/*"
         agents:
+          arch: "aarch64"
           queue: "juliaecosystem"
         env:
           BENCHMARK_GROUP: CPU
           JULIA_NUM_THREADS: "{{matrix.threads}}"
-        timeout_in_minutes: 10
+        timeout_in_minutes: 15
 
       - label: "AMDGPU: Run Benchmarks"
         plugins:

--- a/.buildkite/runbenchmarks.yml
+++ b/.buildkite/runbenchmarks.yml
@@ -27,7 +27,7 @@ steps:
         agents:
           arch: "aarch64"
           queue: "juliaecosystem"
-          num_cpus: "4"
+          num_cpus: "8"
         env:
           BENCHMARK_GROUP: CPU
           JULIA_NUM_THREADS: "{{matrix.threads}}"

--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -29,8 +29,8 @@ steps:
               using Pkg
               Pkg.test("KomaMRICore"; coverage=true, julia_args=`--threads=auto`)'
         agents:
-          queue: "juliagpu"
-        timeout_in_minutes: 60
+          queue: "juliaecosystem"
+        timeout_in_minutes: 10
         
       - label: "AMDGPU: Run tests on v{{matrix.version}}"
         matrix:

--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -20,14 +20,14 @@ steps:
 
           julia -e 'println("--- :julia: Running tests")
               using Pkg
-              Pkg.test("KomaMRICore"; julia_args=`--threads=8`)'
+              Pkg.test("KomaMRICore"; julia_args=`--threads=4`)'
         agents:
           arch: "aarch64" 
           queue: "juliaecosystem"
           num_cpus: "4"
         env:
           TEST_GROUP: $TEST_GROUP
-          JULIA_NUM_THREADS: "8"
+          JULIA_NUM_THREADS: "4"
         timeout_in_minutes: 30
         
       - label: "AMDGPU: Run tests on v{{matrix.version}}"

--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -20,7 +20,7 @@ steps:
 
           julia -e 'println("--- :julia: Running tests")
               using Pkg
-              Pkg.test("KomaMRICore"; julia_args=`--threads=4`)'
+              Pkg.test("KomaMRICore")'
         agents:
           arch: "aarch64" 
           queue: "juliaecosystem"

--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -29,8 +29,9 @@ steps:
               using Pkg
               Pkg.test("KomaMRICore"; coverage=true, julia_args=`--threads=auto`)'
         agents:
+          arch: "aarch64" 
           queue: "juliaecosystem"
-        timeout_in_minutes: 10
+        timeout_in_minutes: 15
         
       - label: "AMDGPU: Run tests on v{{matrix.version}}"
         matrix:

--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -10,9 +10,6 @@ steps:
         plugins:
           - JuliaCI/julia#v1:
               version: "{{matrix.version}}"
-        env:
-          TEST_GROUP: $TEST_GROUP
-          JULIA_NUM_THREADS: "8"
         command: |
           julia -e 'println("--- :julia: Instantiating project")
               using Pkg
@@ -27,6 +24,10 @@ steps:
         agents:
           arch: "aarch64" 
           queue: "juliaecosystem"
+          num_cpus: "4"
+        env:
+          TEST_GROUP: $TEST_GROUP
+          JULIA_NUM_THREADS: "8"
         timeout_in_minutes: 30
         
       - label: "AMDGPU: Run tests on v{{matrix.version}}"

--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -27,11 +27,11 @@ steps:
 
           julia -e 'println("--- :julia: Running tests")
               using Pkg
-              Pkg.test("KomaMRICore"; coverage=true, julia_args=`--threads=auto`)'
+              Pkg.test("KomaMRICore"; julia_args=`--threads=auto`)'
         agents:
           arch: "aarch64" 
           queue: "juliaecosystem"
-        timeout_in_minutes: 15
+        timeout_in_minutes: 30
         
       - label: "AMDGPU: Run tests on v{{matrix.version}}"
         matrix:

--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -10,13 +10,9 @@ steps:
         plugins:
           - JuliaCI/julia#v1:
               version: "{{matrix.version}}"
-          - JuliaCI/julia-coverage#v1:
-              codecov: true
-              dirs:
-                - KomaMRICore/src
-                - KomaMRICore/ext
         env:
           TEST_GROUP: $TEST_GROUP
+          JULIA_NUM_THREADS: "8"
         command: |
           julia -e 'println("--- :julia: Instantiating project")
               using Pkg
@@ -27,7 +23,7 @@ steps:
 
           julia -e 'println("--- :julia: Running tests")
               using Pkg
-              Pkg.test("KomaMRICore"; julia_args=`--threads=auto`)'
+              Pkg.test("KomaMRICore"; julia_args=`--threads=8`)'
         agents:
           arch: "aarch64" 
           queue: "juliaecosystem"


### PR DESCRIPTION
Fixes #501.

Moves CPU tests and benchmarks to the juliaecosystem queue, and reduces max time outs.