### PR TITLE
Adjust reset flag interpolation to trigger at jump

### DIFF
--- a/KomaMRICore/src/simulation/Flow.jl
+++ b/KomaMRICore/src/simulation/Flow.jl
@@ -82,11 +82,11 @@ function replace_view(replace_by, idx)
 end
 
 function get_mask(spin_reset, t::Real)
-   itp  = KomaMRIBase.interpolate(spin_reset, KomaMRIBase.Gridded(KomaMRIBase.Constant{KomaMRIBase.Previous}()), Val(size(spin_reset, 1)), t)
+   itp  = KomaMRIBase.interpolate(spin_reset, KomaMRIBase.Gridded(KomaMRIBase.Constant{KomaMRIBase.Next}()), Val(size(spin_reset, 1)), t)
    return KomaMRIBase.resample(itp, t)
 end
 function get_mask(spin_reset, t::AbstractArray)
-   itp  = KomaMRIBase.interpolate(spin_reset, KomaMRIBase.Gridded(KomaMRIBase.Constant{KomaMRIBase.Previous}()), Val(size(spin_reset, 1)), t)
+   itp  = KomaMRIBase.interpolate(spin_reset, KomaMRIBase.Gridded(KomaMRIBase.Constant{KomaMRIBase.Next}()), Val(size(spin_reset, 1)), t)
    mask = KomaMRIBase.resample(itp, t)
    mask .= (cumsum(mask; dims=2) .== 1)
    return mask


### PR DESCRIPTION
Testing with `FlowPath`, I realized that the interpolation of the reset flag is performed using the `Constant{Previous}` option. This required the `spin_reset` matrix to be `true` one time step before the jump, which doesn't make much sense.

I believe it’s better for `spin_reset` to activate at the time node where the jump occurs, rather than the one before it. This approach simplifies phantom design and seems more intuitive.

For a single spin, where the jump occurs when the spin exits at the top (`dz` = 4) and reenters at the bottom (`dz` = -4): 

Previously, the phantom had to be designed like this:
```
dz         = [1 2 3 4 -4 -3 -1 -1]  
spin_reset = [0 0 0 1  0  0  0  0]  
```
Now:
```
dz         = [1 2 3 4 -4 -3 -1 -1]  
spin_reset = [0 0 0 0  1  0  0  0]  
```

So, this PR only changes `Previous` to `Next` in `outflow_spin_reset!`.