### PR TITLE
Limit 'NadcsPerImage' to be at least 1

### DIFF
--- a/KomaMRICore/src/rawdata/ISMRMRD.jl
+++ b/KomaMRICore/src/rawdata/ISMRMRD.jl
@@ -154,7 +154,7 @@ function signal_to_raw_data(
     profiles = Profile[]
     t_acq = get_adc_sampling_times(seq)
     Nadcs = sum(is_ADC_on.(seq))
-    NadcsPerImage = floor(Int, Nadcs / Nz)
+    NadcsPerImage = max(floor(Int, Nadcs / Nz), 1)
     scan_counter = 0
     nz = 0
     current = 1


### PR DESCRIPTION
As "NadcsPerImage" shouldn't ever be less than 1, it gets limited to be the at least 1. This implementation avoids a possible division by 0 in `ISMRMRD.jl`, Solving the Issue #409 :
```julia
if scan_counter % NadcsPerImage == 0 #For now only Nz is considered
    nz += 1 #another image
    scan_counter = 0 #reset counter
end
```