### PR TITLE
Adding standard T1 and T2 colormaps from QMRIColors.jl

### DIFF
--- a/KomaMRIPlots/Project.toml
+++ b/KomaMRIPlots/Project.toml
@@ -25,7 +25,7 @@ KomaMRIBase = "0.9"
 MAT = "0.10"
 PlotlyJS = "0.18"
 PlutoPlotly = "0.4, 0.5"
-QMRIColors = "1.0.0"
+QMRIColors = "1"
 Reexport = "1"
 julia = "1.9"
 

--- a/KomaMRIPlots/Project.toml
+++ b/KomaMRIPlots/Project.toml
@@ -9,6 +9,7 @@ Kaleido_jll = "f7e6163d-2fa5-5f23-b69c-1db539e41963"
 KomaMRIBase = "d0bc0b20-b151-4d03-b2a4-6ca51751cb9c"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
+QMRIColors = "2bec176e-9e8c-4764-a62f-295118d1ec05"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [weakdeps]
@@ -24,6 +25,7 @@ KomaMRIBase = "0.9"
 MAT = "0.10"
 PlotlyJS = "0.18"
 PlutoPlotly = "0.4, 0.5"
+QMRIColors = "1.0.0"
 Reexport = "1"
 julia = "1.9"
 

--- a/KomaMRIPlots/src/KomaMRIPlots.jl
+++ b/KomaMRIPlots/src/KomaMRIPlots.jl
@@ -2,6 +2,7 @@ module KomaMRIPlots
 
 using KomaMRIBase
 using MAT, Interpolations, PlotlyJS
+using QMRIColors
 
 include("ui/PlotBackends.jl")
 include("ui/DisplayFunctions.jl")

--- a/KomaMRIPlots/src/ui/DisplayFunctions.jl
+++ b/KomaMRIPlots/src/ui/DisplayFunctions.jl
@@ -981,10 +981,10 @@ function plot_kspace(seq::Sequence; width=nothing, height=nothing, darkmode=fals
             "orbitRotation",
             "resetCameraDefault3d",
         ],
-    )
-    return plot_koma(p, l; config)
-end
-
+        )
+        return plot_koma(p, l; config)
+    end
+    
 """
     p = plot_phantom_map(obj::Phantom, key::Symbol; kwargs...)
 
@@ -1080,38 +1080,12 @@ function plot_phantom_map(
         unit = " ms"
         if key == :T1
             cmax_key = 2500 / factor
-            colors = MAT.matread(path * "/assets/T1cm.mat")["T1colormap"][1:70:end, :]
-            N, _ = size(colors)
-            idx = range(0, 1; length=N) #range(0,T,N) works in Julia 1.7
-            colormap = [
-                (
-                    idx[n],
-                    string("rgb(", 
-                        floor(Int, colors[n,1] * 255), ",",
-                        floor(Int, colors[n,2] * 255), ",",
-                        floor(Int, colors[n,3] * 255), ")"
-                        )
-                ) 
-                for n in 1:N
-            ]
+            colormap = relaxationColorMap("T1")
         elseif key == :T2 || key == :T2s
             if key == :T2
                 cmax_key = 250 / factor
             end
-            colors = MAT.matread(path * "/assets/T2cm.mat")["T2colormap"][1:70:end, :]
-            N, _ = size(colors)
-            idx = range(0, 1; length=N) #range(0,T,N) works in Julia 1.7
-            colormap = [
-                (
-                    idx[n],
-                    string("rgb(", 
-                        floor(Int, colors[n,1] * 255), ",",
-                        floor(Int, colors[n,2] * 255), ",",
-                        floor(Int, colors[n,3] * 255), ")"
-                        )
-                ) 
-                for n in 1:N
-            ]
+            colormap = relaxationColorMap("T2")
         end
     elseif key == :x || key == :y || key == :z
         factor = 1e2

--- a/KomaMRIPlots/src/ui/DisplayFunctions.jl
+++ b/KomaMRIPlots/src/ui/DisplayFunctions.jl
@@ -1080,42 +1080,20 @@ function plot_phantom_map(
         unit = " ms"
         if key == :T1
             cmax_key = 2500 / factor
-            colors = relaxationColorMap("T1")
+            colors =
+                replace.(string.(relaxationColorMap("T1") .* 255), "RGB{Float64}" => "rgb")
             N = length(colors)
-            idx = range(0, 1; length=N)
-        
-            # Create the colormap
-            colormap = [
-                (
-                    idx[n],
-                    string("rgb(",
-                        floor(Int, colors[n].r * 255), ",",
-                        floor(Int, colors[n].g * 255), ",",
-                        floor(Int, colors[n].b * 255), ")"
-                    )
-                )
-                for n in 1:N
-            ]        
+            indices = range(0.0; stop=1.0, length=N)
+            colormap = [(idx, color) for (idx, color) in zip(indices, colors)]
         elseif key == :T2 || key == :T2s
             if key == :T2
                 cmax_key = 250 / factor
             end
-            colors = relaxationColorMap("T2")
+            colors =
+                replace.(string.(relaxationColorMap("T2") .* 255), "RGB{Float64}" => "rgb")
             N = length(colors)
-            idx = range(0, 1; length=N)
-        
-            # Create the colormap
-            colormap = [
-                (
-                    idx[n],
-                    string("rgb(",
-                        floor(Int, colors[n].r * 255), ",",
-                        floor(Int, colors[n].g * 255), ",",
-                        floor(Int, colors[n].b * 255), ")"
-                    )
-                )
-                for n in 1:N
-            ]    
+            indices = range(0.0; stop=1.0, length=N)
+            colormap = [(idx, color) for (idx, color) in zip(indices, colors)]
         end
     elseif key == :x || key == :y || key == :z
         factor = 1e2

--- a/KomaMRIPlots/src/ui/DisplayFunctions.jl
+++ b/KomaMRIPlots/src/ui/DisplayFunctions.jl
@@ -980,11 +980,11 @@ function plot_kspace(seq::Sequence; width=nothing, height=nothing, darkmode=fals
             "resetCameraLastSave3d",
             "orbitRotation",
             "resetCameraDefault3d",
-        ],
-        )
-        return plot_koma(p, l; config)
-    end
-    
+    ],
+    )
+    return plot_koma(p, l; config)
+end
+
 """
     p = plot_phantom_map(obj::Phantom, key::Symbol; kwargs...)
 

--- a/KomaMRIPlots/src/ui/DisplayFunctions.jl
+++ b/KomaMRIPlots/src/ui/DisplayFunctions.jl
@@ -1080,12 +1080,42 @@ function plot_phantom_map(
         unit = " ms"
         if key == :T1
             cmax_key = 2500 / factor
-            colormap = relaxationColorMap("T1")
+            colors = relaxationColorMap("T1")
+            N = length(colors)
+            idx = range(0, 1; length=N)
+        
+            # Create the colormap
+            colormap = [
+                (
+                    idx[n],
+                    string("rgb(",
+                        floor(Int, colors[n].r * 255), ",",
+                        floor(Int, colors[n].g * 255), ",",
+                        floor(Int, colors[n].b * 255), ")"
+                    )
+                )
+                for n in 1:N
+            ]        
         elseif key == :T2 || key == :T2s
             if key == :T2
                 cmax_key = 250 / factor
             end
-            colormap = relaxationColorMap("T2")
+            colors = relaxationColorMap("T2")
+            N = length(colors)
+            idx = range(0, 1; length=N)
+        
+            # Create the colormap
+            colormap = [
+                (
+                    idx[n],
+                    string("rgb(",
+                        floor(Int, colors[n].r * 255), ",",
+                        floor(Int, colors[n].g * 255), ",",
+                        floor(Int, colors[n].b * 255), ")"
+                    )
+                )
+                for n in 1:N
+            ]    
         end
     elseif key == :x || key == :y || key == :z
         factor = 1e2


### PR DESCRIPTION
Replace the T1 and T2 colormap definition from a ".mat" file to the standard colormap definition in QMRIColors.jl.

This PR solves the Issue #473