### PR TITLE
Bump compat for AMDGPU to 1.2.2 for package KomaMRICore

### DIFF
--- a/KomaMRICore/Project.toml
+++ b/KomaMRICore/Project.toml
@@ -25,7 +25,7 @@ KomaMetalExt = "Metal"
 KomaoneAPIExt = "oneAPI"
 
 [compat]
-AMDGPU = "0.9, 1"
+AMDGPU = "0.9, 1.2.2"
 Adapt = "3, 4"
 CUDA = "3, 4, 5"
 Functors = "0.4, 0.5"


### PR DESCRIPTION
This PR aims to make it mandatory to use the new version 1.2.2 of AMDGPU.jl, in order to avoid issues with the new version of GPUArrays.jl.