### PR TITLE
replace all "cmin" and "cmax" with "zmin" and "zmax" respectibly

### DIFF
--- a/KomaMRIPlots/src/ui/DisplayFunctions.jl
+++ b/KomaMRIPlots/src/ui/DisplayFunctions.jl
@@ -1168,8 +1168,8 @@ function plot_phantom_map(
                             showscale=colorbar,
                             colorscale=colormap,
                             colorbar=attr(ticksuffix=unit, title=string(key)),
-                            zmin=cmin_key,
-                            zmax=cmax_key,
+                            cmin=cmin_key,
+                            cmax=cmax_key,
                             size=4
                             ),
                 visible=i==1,
@@ -1221,8 +1221,8 @@ function plot_phantom_map(
                             showscale=colorbar,
                             colorscale=colormap,
                             colorbar=attr(ticksuffix=unit, title=string(key)),
-                            zmin=cmin_key,
-                            zmax=cmax_key,
+                            cmin=cmin_key,
+                            cmax=cmax_key,
                             size=2
                             ),
                 visible=i==1,

--- a/KomaMRIPlots/src/ui/DisplayFunctions.jl
+++ b/KomaMRIPlots/src/ui/DisplayFunctions.jl
@@ -1073,14 +1073,14 @@ function plot_phantom_map(
     end
 
     path = @__DIR__
-    zmin_key = minimum(getproperty(obj, key))
-    zmax_key = maximum(getproperty(obj, key))
+    cmin_key = minimum(getproperty(obj, key))
+    cmax_key = maximum(getproperty(obj, key))
     if key == :T1 || key == :T2 || key == :T2s
-        zmin_key = 0
+        cmin_key = 0
         factor = 1e3
         unit = " ms"
         if key == :T1
-            zmax_key = 2500 / factor
+            cmax_key = 2500 / factor
             colors =
                 replace.(string.(relaxationColorMap("T1") .* 255), "RGB{Float64}" => "rgb")
             N = length(colors)
@@ -1088,7 +1088,7 @@ function plot_phantom_map(
             colormap = [(idx, color) for (idx, color) in zip(indices, colors)]
         elseif key == :T2 || key == :T2s
             if key == :T2
-                zmax_key = 250 / factor
+                cmax_key = 250 / factor
             end
             colors =
                 replace.(string.(relaxationColorMap("T2") .* 255), "RGB{Float64}" => "rgb")
@@ -1106,12 +1106,12 @@ function plot_phantom_map(
         colormap = "Greys"
     else
         factor = 1
-        zmin_key = 0
+        cmin_key = 0
         unit = ""
         colormap = "Greys"
     end
-    zmin_key = get(kwargs, :zmin, factor * zmin_key)
-    zmax_key = get(kwargs, :zmax, factor * zmax_key)
+    cmin_key = get(kwargs, :zmin, factor * cmin_key)
+    cmax_key = get(kwargs, :zmax, factor * cmax_key)
 
     t = process_times(obj.motion)
     x, y, z = get_spin_coords(obj.motion, obj.x, obj.y, obj.z, t')
@@ -1168,8 +1168,8 @@ function plot_phantom_map(
                             showscale=colorbar,
                             colorscale=colormap,
                             colorbar=attr(ticksuffix=unit, title=string(key)),
-                            zmin=zmin_key,
-                            zmax=zmax_key,
+                            zmin=cmin_key,
+                            zmax=cmax_key,
                             size=4
                             ),
                 visible=i==1,
@@ -1221,8 +1221,8 @@ function plot_phantom_map(
                             showscale=colorbar,
                             colorscale=colormap,
                             colorbar=attr(ticksuffix=unit, title=string(key)),
-                            zmin=zmin_key,
-                            zmax=zmax_key,
+                            zmin=cmin_key,
+                            zmax=cmax_key,
                             size=2
                             ),
                 visible=i==1,

--- a/KomaMRIPlots/src/ui/DisplayFunctions.jl
+++ b/KomaMRIPlots/src/ui/DisplayFunctions.jl
@@ -1073,14 +1073,14 @@ function plot_phantom_map(
     end
 
     path = @__DIR__
-    cmin_key = minimum(getproperty(obj, key))
-    cmax_key = maximum(getproperty(obj, key))
+    zmin_key = minimum(getproperty(obj, key))
+    zmax_key = maximum(getproperty(obj, key))
     if key == :T1 || key == :T2 || key == :T2s
-        cmin_key = 0
+        zmin_key = 0
         factor = 1e3
         unit = " ms"
         if key == :T1
-            cmax_key = 2500 / factor
+            zmax_key = 2500 / factor
             colors =
                 replace.(string.(relaxationColorMap("T1") .* 255), "RGB{Float64}" => "rgb")
             N = length(colors)
@@ -1088,7 +1088,7 @@ function plot_phantom_map(
             colormap = [(idx, color) for (idx, color) in zip(indices, colors)]
         elseif key == :T2 || key == :T2s
             if key == :T2
-                cmax_key = 250 / factor
+                zmax_key = 250 / factor
             end
             colors =
                 replace.(string.(relaxationColorMap("T2") .* 255), "RGB{Float64}" => "rgb")
@@ -1106,12 +1106,12 @@ function plot_phantom_map(
         colormap = "Greys"
     else
         factor = 1
-        cmin_key = 0
+        zmin_key = 0
         unit = ""
         colormap = "Greys"
     end
-    cmin_key = get(kwargs, :cmin, factor * cmin_key)
-    cmax_key = get(kwargs, :cmax, factor * cmax_key)
+    zmin_key = get(kwargs, :zmin, factor * zmin_key)
+    zmax_key = get(kwargs, :zmax, factor * zmax_key)
 
     t = process_times(obj.motion)
     x, y, z = get_spin_coords(obj.motion, obj.x, obj.y, obj.z, t')
@@ -1168,8 +1168,8 @@ function plot_phantom_map(
                             showscale=colorbar,
                             colorscale=colormap,
                             colorbar=attr(ticksuffix=unit, title=string(key)),
-                            cmin=cmin_key,
-                            cmax=cmax_key,
+                            zmin=zmin_key,
+                            zmax=zmax_key,
                             size=4
                             ),
                 visible=i==1,
@@ -1221,8 +1221,8 @@ function plot_phantom_map(
                             showscale=colorbar,
                             colorscale=colormap,
                             colorbar=attr(ticksuffix=unit, title=string(key)),
-                            cmin=cmin_key,
-                            cmax=cmax_key,
+                            zmin=zmin_key,
+                            zmax=zmax_key,
                             size=2
                             ),
                 visible=i==1,


### PR DESCRIPTION
To improve consistency as requested in Issue #361 , every keyword "cmin/cmax" was replaced with "zmin/zmax" , as it was described with that notation in the keywords description for the plot_image function.