### PR TITLE
Update `Rotate` `displacement!` functions to center coordinates before applying the rotation

### DIFF
--- a/KomaMRIBase/src/motion/actions/simpleactions/Rotate.jl
+++ b/KomaMRIBase/src/motion/actions/simpleactions/Rotate.jl
@@ -66,9 +66,15 @@ function displacement_x!(ux, action::Rotate, x, y, z, t)
     α = t .* (action.yaw*π/180)
     β = t .* (action.roll*π/180)
     γ = t .* (action.pitch*π/180)
-    ux .= cos.(α) .* cos.(β) .* x +
-         (cos.(α) .* sin.(β) .* sin.(γ) .- sin.(α) .* cos.(γ)) .* y +
-         (cos.(α) .* sin.(β) .* cos.(γ) .+ sin.(α) .* sin.(γ)) .* z .- x
+    cx = (maximum(x) + minimum(x)) / 2
+    cy = (maximum(y) + minimum(y)) / 2
+    cz = (maximum(z) + minimum(z)) / 2
+    x0 = x .- cx
+    y0 = y .- cy
+    z0 = z .- cz
+    ux .= cos.(α) .* cos.(β) .* x0 +
+         (cos.(α) .* sin.(β) .* sin.(γ) .- sin.(α) .* cos.(γ)) .* y0 +
+         (cos.(α) .* sin.(β) .* cos.(γ) .+ sin.(α) .* sin.(γ)) .* z0 .+ cx .- x
     return nothing
 end
 
@@ -76,9 +82,15 @@ function displacement_y!(uy, action::Rotate, x, y, z, t)
     α = t .* (action.yaw*π/180)
     β = t .* (action.roll*π/180)
     γ = t .* (action.pitch*π/180)
-    uy .= sin.(α) .* cos.(β) .* x +
-         (sin.(α) .* sin.(β) .* sin.(γ) .+ cos.(α) .* cos.(γ)) .* y +
-         (sin.(α) .* sin.(β) .* cos.(γ) .- cos.(α) .* sin.(γ)) .* z .- y
+    cx = (maximum(x) + minimum(x)) / 2
+    cy = (maximum(y) + minimum(y)) / 2
+    cz = (maximum(z) + minimum(z)) / 2
+    x0 = x .- cx
+    y0 = y .- cy
+    z0 = z .- cz
+    uy .= sin.(α) .* cos.(β) .* x0 +
+         (sin.(α) .* sin.(β) .* sin.(γ) .+ cos.(α) .* cos.(γ)) .* y0 +
+         (sin.(α) .* sin.(β) .* cos.(γ) .- cos.(α) .* sin.(γ)) .* z0 .+ cy .- y
     return nothing
 end
 
@@ -86,8 +98,14 @@ function displacement_z!(uz, action::Rotate, x, y, z, t)
     α = t .* (action.yaw*π/180)
     β = t .* (action.roll*π/180)
     γ = t .* (action.pitch*π/180)
-    uz .=  -sin.(β) .* x + 
-            cos.(β) .* sin.(γ) .* y +
-            cos.(β) .* cos.(γ) .* z .- z
+    cx = (maximum(x) + minimum(x)) / 2
+    cy = (maximum(y) + minimum(y)) / 2
+    cz = (maximum(z) + minimum(z)) / 2
+    x0 = x .- cx
+    y0 = y .- cy
+    z0 = z .- cz
+    uz .=  -sin.(β) .* x0 + 
+            cos.(β) .* sin.(γ) .* y0 +
+            cos.(β) .* cos.(γ) .* z0 .+ cz .- z
     return nothing
 end


### PR DESCRIPTION
This change ensures that the rotation is always performed around the geometric center of the phantom, rather than the origin (0, 0, 0). There may be cases where the phantom has an offset in one of its coordinates, and in such cases, rotating around the origin would not be meaningful. This adjustment ensures the rotation is applied correctly relative to the phantom's actual position.