### PR TITLE
Modificaton of use: Phantom{Float64}() -> Phantom()

### DIFF
--- a/KomaMRIBase/src/datatypes/Phantom.jl
+++ b/KomaMRIBase/src/datatypes/Phantom.jl
@@ -271,7 +271,7 @@ function brain_phantom2D(; axis="axial", ss=4, us=1, tissue_properties = Dict())
     ρ, T1, T2, T2s, Δw = default_brain_tissue_properties(labels, tissue_properties)
     
     # Define and return the Phantom struct
-    obj = Phantom{Float64}(;
+    obj = Phantom(;
         name="brain2D_" * axis,
         x=y[ρ .!= 0],
         y=x[ρ .!= 0],
@@ -364,7 +364,7 @@ function brain_phantom3D(; ss=4, us=1, start_end=[160, 200], tissue_properties=D
     ρ, T1, T2, T2s, Δw = default_brain_tissue_properties(labels, tissue_properties)
 
     # Define and return the Phantom struct
-    obj = Phantom{Float64}(;
+    obj = Phantom(;
         name="brain3D",
         x=y[ρ .!= 0],
         y=x[ρ .!= 0],
@@ -448,7 +448,7 @@ function pelvis_phantom2D(; ss=4, us=1)
     T2s = T2s * 1e-3
 
     # Define and return the Phantom struct
-    obj = Phantom{Float64}(;
+    obj = Phantom(;
         name="pelvis2D",
         x=y[ρ .!= 0],
         y=x[ρ .!= 0],

--- a/KomaMRICore/src/simulation/SimulatorCore.jl
+++ b/KomaMRICore/src/simulation/SimulatorCore.jl
@@ -459,7 +459,7 @@ function simulate_slice_profile(
 )
     sim_params["return_type"] = "state"
     sys = Scanner()
-    obj = Phantom{Float64}(; x=zeros(size(z)), z=Array(z))
+    obj = Phantom(; x=zeros(size(z)), z=Array(z))
     mag = simulate(obj, seq, sys; sim_params)
     return mag
 end

--- a/KomaMRICore/test/runtests.jl
+++ b/KomaMRICore/test/runtests.jl
@@ -254,7 +254,7 @@ end
     N = 6
 
     sys = Scanner()
-    obj = Phantom{Float64}(x=[0.],T1=[T1],T2=[T2],Δw=[Δw])
+    obj = Phantom(x=[0.],T1=[T1],T2=[T2],Δw=[Δw])
 
     rf_phase = [0, π/2]
     seq = Sequence()
@@ -301,7 +301,7 @@ end
     N = 6
 
     sys = Scanner()
-    obj = Phantom{Float64}(x=[0.],T1=[T1],T2=[T2],Δw=[Δw])
+    obj = Phantom(x=[0.],T1=[T1],T2=[T2],Δw=[Δw])
 
     rf_phase = 2π*rand()
     seq1 = Sequence()
@@ -325,7 +325,7 @@ end
     include(joinpath(@__DIR__, "test_files", "utils.jl"))
 
     seq = seq_epi_100x100_TE100_FOV230()
-    obj = Phantom{Float64}(x=[0.], T1=[1000e-3], T2=[100e-3])
+    obj = Phantom(x=[0.], T1=[1000e-3], T2=[100e-3])
     sys = Scanner()
     sim_params = Dict(
         "gpu"=>USE_GPU,

--- a/docs/src/how-to/3-create-your-own-phantom.md
+++ b/docs/src/how-to/3-create-your-own-phantom.md
@@ -114,7 +114,7 @@ T2s = T2s*1e-3
 Finally, we can invoke the [`Phantom`](@ref) constructor. However, before doing so, we choose not to store spins where the proton density is zero to avoid unnecessary data storage. This is achieved by applying the mask `ρ.!=0` to the arrays. Additionally, please note that we set the z-position array filled with zeros.
 ```julia
 # Define the phantom
-obj = Phantom{Float64}(
+obj = Phantom(
     name = "custom-pelvis",
 	x = x[ρ.!=0],
 	y = y[ρ.!=0],

--- a/examples/3.tutorials/lit-01-FID.jl
+++ b/examples/3.tutorials/lit-01-FID.jl
@@ -39,7 +39,7 @@ p1 = plot_seq(seq; slider=false, height=300)
 # Now, we will define a `Phantom` with a single spin at ``x=0``
 # with ``T_1=1000\,\mathrm{ms}`` and ``T_2=100\,\mathrm{ms}``.
 
-obj = Phantom{Float64}(x=[0.], T1=[1000e-3], T2=[100e-3])
+obj = Phantom(x=[0.], T1=[1000e-3], T2=[100e-3])
 
 # Finally, to simulate we will need to use the function [`simulate`](@ref).
 
@@ -62,7 +62,7 @@ p2 = plot_signal(raw; slider=false, height=300)
 # We will use ``\Delta f=-100\,\mathrm{Hz}``.
 # For this, we will need to add a definition for `Δw` in our `Phantom`
 
-obj = Phantom{Float64}(x=[0.], T1=[1000e-3], T2=[100e-3], Δw=[-2π*100])# and simulate again.
+obj = Phantom(x=[0.], T1=[1000e-3], T2=[100e-3], Δw=[-2π*100])# and simulate again.
 
 raw = simulate(obj, seq, sys)
 p3 = plot_signal(raw; slider=false, height=300)

--- a/examples/4.reproducible_notebooks/pluto-02-low-field-cmra-optimization.jl
+++ b/examples/4.reproducible_notebooks/pluto-02-low-field-cmra-optimization.jl
@@ -259,13 +259,13 @@ end
 # ╔═╡ f57a2b6c-eb4c-45bd-8058-4a60b038925d
 begin
 	function cardiac_phantom(off; off_fat=fat_freq)
-	    myocard = Phantom{Float64}(x=dx, ρ=0.6*ones(Niso), T1=701e-3*ones(Niso),
+	    myocard = Phantom(x=dx, ρ=0.6*ones(Niso), T1=701e-3*ones(Niso),
 	                               T2=58e-3*ones(Niso),    Δw=2π*off*ones(Niso))
-	    blood =   Phantom{Float64}(x=dx, ρ=0.7*ones(Niso), T1=1122e-3*ones(Niso),
+	    blood =   Phantom(x=dx, ρ=0.7*ones(Niso), T1=1122e-3*ones(Niso),
 	                               T2=263e-3*ones(Niso),   Δw=2π*off*ones(Niso))
-	    fat1 =    Phantom{Float64}(x=dx, ρ=1.0*ones(Niso), T1=183e-3*ones(Niso),
+	    fat1 =    Phantom(x=dx, ρ=1.0*ones(Niso), T1=183e-3*ones(Niso),
 	                               T2=93e-3*ones(Niso),    Δw=2π*(off_fat + off)*ones(Niso))
-	    fat2 =    Phantom{Float64}(x=dx, ρ=1.0*ones(Niso), T1=130e-3*ones(Niso),
+	    fat2 =    Phantom(x=dx, ρ=1.0*ones(Niso), T1=130e-3*ones(Niso),
 	                               T2=93e-3*ones(Niso),    Δw=2π*(off_fat + off)*ones(Niso))
 	    obj = myocard + blood + fat1 + fat2
 	    return obj

--- a/examples/4.reproducible_notebooks/pluto-03-low-field-boost-optimization.jl
+++ b/examples/4.reproducible_notebooks/pluto-03-low-field-boost-optimization.jl
@@ -321,13 +321,13 @@ end
 # ╔═╡ f57a2b6c-eb4c-45bd-8058-4a60b038925d
 begin
 	function cardiac_phantom(off; off_fat=fat_freq)
-	    myocard = Phantom{Float64}(x=dx, ρ=0.6*ones(Niso), T1=701e-3*ones(Niso),
+	    myocard = Phantom(x=dx, ρ=0.6*ones(Niso), T1=701e-3*ones(Niso),
 	                               T2=58e-3*ones(Niso),    Δw=2π*off*ones(Niso))
-	    blood =   Phantom{Float64}(x=dx, ρ=0.7*ones(Niso), T1=1122e-3*ones(Niso),
+	    blood =   Phantom(x=dx, ρ=0.7*ones(Niso), T1=1122e-3*ones(Niso),
 	                               T2=263e-3*ones(Niso),   Δw=2π*off*ones(Niso))
-	    fat1 =    Phantom{Float64}(x=dx, ρ=1.0*ones(Niso), T1=183e-3*ones(Niso),
+	    fat1 =    Phantom(x=dx, ρ=1.0*ones(Niso), T1=183e-3*ones(Niso),
 	                               T2=93e-3*ones(Niso),    Δw=2π*(off_fat + off)*ones(Niso))
-	    fat2 =    Phantom{Float64}(x=dx, ρ=1.0*ones(Niso), T1=130e-3*ones(Niso),
+	    fat2 =    Phantom(x=dx, ρ=1.0*ones(Niso), T1=130e-3*ones(Niso),
 	                               T2=93e-3*ones(Niso),    Δw=2π*(off_fat + off)*ones(Niso))
 	    obj = myocard + blood + fat1 + fat2
 	    return obj

--- a/src/KomaUI.jl
+++ b/src/KomaUI.jl
@@ -1,7 +1,7 @@
 # Define observables exported observables
 sys_ui = Observable{Scanner}(Scanner())
 seq_ui = Observable{Sequence}(Sequence())
-obj_ui = Observable{Phantom{Float64}}(Phantom{Float64}(x=[0.0]))
+obj_ui = Observable{Phantom}(Phantom(x=[0.0]))
 raw_ui = Observable{RawAcquisitionData}(setup_raw())
 img_ui = Observable{Array{ComplexF64}}([0.0im 0.; 0. 0.])
 


### PR DESCRIPTION
This pull request solves issue #576.

Given the change of how to use Phantom in earlier updates,  this PR updates the call of the Phantom structure in examples, tests and definitions from Phantom{Float64}() to Phantom()