### PR TITLE
Complex Phantom rho support

### DIFF
--- a/KomaMRIBase/src/datatypes/Phantom.jl
+++ b/KomaMRIBase/src/datatypes/Phantom.jl
@@ -34,7 +34,7 @@ julia> obj.ρ
     x::AbstractVector{T}   = @isdefined(T) ? T[] : Float64[]
     y::AbstractVector{T}   = zeros(eltype(x), size(x))
     z::AbstractVector{T}   = zeros(eltype(x), size(x))
-    ρ::AbstractVector{T}   = ones(eltype(x), size(x))
+    ρ::AbstractVector{<:Union{T, Complex{T}}}   = ones(eltype(x), size(x))
     T1::AbstractVector{T}  = ones(eltype(x), size(x)) * 1_000_000
     T2::AbstractVector{T}  = ones(eltype(x), size(x)) * 1_000_000
     T2s::AbstractVector{T} = ones(eltype(x), size(x)) * 1_000_000

--- a/KomaMRICore/src/simulation/SimMethods/Bloch/cpu/BlochCPU.jl
+++ b/KomaMRICore/src/simulation/SimMethods/Bloch/cpu/BlochCPU.jl
@@ -102,7 +102,7 @@ function run_spin_precession!(
 
     #Final Spin-State
     @. M.xy = M.xy * exp(-t_seq / p.T2) * cis(ϕ)
-    @. M.z = M.z * exp(-t_seq / p.T1) + p.ρ * (T(1) - exp(-t_seq / p.T1))
+    @. M.z = M.z * exp(-t_seq / p.T1) + abs.(p.ρ) * (T(1) - exp(-t_seq / p.T1))
     
     #Reset Spin-State (Magnetization). Only for FlowPath
     outflow_spin_reset!(M,  seq.t', p.motion; replace_by=p.ρ)
@@ -150,7 +150,7 @@ function run_spin_excitation!(
         mul!(Spinor(α, β), M, Maux_xy, Maux_z)
         #Relaxation
         @. M.xy = M.xy * exp(-s.Δt / p.T2)
-        @. M.z = M.z * exp(-s.Δt / p.T1) + p.ρ * (T(1) - exp(-s.Δt / p.T1))
+        @. M.z = M.z * exp(-s.Δt / p.T1) + abs.(p.ρ) * (T(1) - exp(-s.Δt / p.T1))
         
         #Reset Spin-State (Magnetization). Only for FlowPath
         outflow_spin_reset!(M,  s.t, p.motion; replace_by=p.ρ)

--- a/KomaMRICore/src/simulation/SimMethods/Bloch/gpu/ExcitationKernel.jl
+++ b/KomaMRICore/src/simulation/SimMethods/Bloch/gpu/ExcitationKernel.jl
@@ -60,7 +60,7 @@
             ΔT2 = exp(-Δt / T2)
             Mxy_r = Mxy_new_r * ΔT2
             Mxy_i = Mxy_new_i * ΔT2
-            Mz = Mz_new * ΔT1 + ρ * (T(1) - ΔT1)
+            Mz = Mz_new * ΔT1 + abs.(ρ) * (T(1) - ΔT1)
             s_idx += 1u32
         end
 

--- a/KomaMRICore/src/simulation/SimMethods/Bloch/gpu/PrecessionKernel.jl
+++ b/KomaMRICore/src/simulation/SimMethods/Bloch/gpu/PrecessionKernel.jl
@@ -85,7 +85,7 @@
         ΔT2 = exp(-t / T2)
         cis_ϕ_i, cis_ϕ_r = sincos(ϕ)
         M_xy[i] = complex(ΔT2 * (Mxy_r * cis_ϕ_r - Mxy_i * cis_ϕ_i), ΔT2 * (Mxy_r * cis_ϕ_i + Mxy_i * cis_ϕ_r))
-        M_z[i] = M_z[i] * ΔT1 + p_ρ[i] * (T(1) - ΔT1)
+        M_z[i] = M_z[i] * ΔT1 + abs.(p_ρ[i]) * (T(1) - ΔT1)
     end
 end
 

--- a/KomaMRICore/src/simulation/SimMethods/BlochSimple/BlochSimple.jl
+++ b/KomaMRICore/src/simulation/SimMethods/BlochSimple/BlochSimple.jl
@@ -47,7 +47,7 @@ function run_spin_precession!(
     dur  = sum(seq.Δt)   # Total length, used for signal relaxation
     Mxy  = [M.xy M.xy .* exp.(-tp' ./ p.T2) .* cis.(ϕ)] #This assumes Δw and T2 are constant in time
     M.xy .= Mxy[:, end]
-    M.z  .= M.z .* exp.(-dur ./ p.T1) .+ p.ρ .* (1 .- exp.(-dur ./ p.T1))
+    M.z  .= M.z .* exp.(-dur ./ p.T1) .+ abs.(p.ρ) .* (1 .- exp.(-dur ./ p.T1))
     #Reset Spin-State (Magnetization). Only for FlowPath
     outflow_spin_reset!(Mxy, seq.t', p.motion)
     outflow_spin_reset!(M, seq.t', p.motion; replace_by=p.ρ)
@@ -95,7 +95,7 @@ function run_spin_excitation!(
         mul!(Q(φ, s.B1 ./ B, Bz ./ B), M)
         #Relaxation
         M.xy .= M.xy .* exp.(-s.Δt ./ p.T2)
-        M.z .= M.z .* exp.(-s.Δt ./ p.T1) .+ p.ρ .* (1 .- exp.(-s.Δt ./ p.T1))
+        M.z .= M.z .* exp.(-s.Δt ./ p.T1) .+ abs.(p.ρ) .* (1 .- exp.(-s.Δt ./ p.T1))
         #Reset Spin-State (Magnetization). Only for FlowPath
         outflow_spin_reset!(M, s.t, p.motion; replace_by=p.ρ)
     end

--- a/KomaMRICore/src/simulation/SimMethods/SimulationMethod.jl
+++ b/KomaMRICore/src/simulation/SimMethods/SimulationMethod.jl
@@ -19,7 +19,7 @@ function initialize_spins_state(
 ) where {T<:Real}
     Nspins = length(obj)
     Mxy = zeros(T, Nspins)
-    Mz = obj.ρ
+    Mz = abs.(obj.ρ)
     Xt = Mag{T}(Mxy, Mz)
     return Xt, obj
 end


### PR DESCRIPTION
Update the handling of the ρ field from Phantom to support complex numbers, ensuring that all calculations involving ρ to obtain `Mz` now use its absolute value.