### PR TITLE
Comment documentation preview links

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,110 @@
+name: Docs Preview
+
+on:
+  pull_request:
+    types:
+      - closed
+  workflow_job:
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  comment:
+    if: >-
+      github.event_name == 'workflow_job' &&
+      github.event.workflow_job.name == 'Documentation' &&
+      github.event.workflow_job.conclusion == 'success'
+    name: Comment documentation preview URL
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find pull request
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullRequests = context.payload.workflow_job.pull_requests;
+            if (!pullRequests || pullRequests.length !== 1) {
+              core.info(`Expected one pull request, found ${pullRequests?.length ?? 0}.`);
+              return;
+            }
+
+            const pr = pullRequests[0];
+            const { data } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            if (!data.labels.some(label => label.name === 'documentation')) {
+              core.info('Pull request does not have the documentation label.');
+              return;
+            }
+
+            core.setOutput('number', pr.number);
+
+      - name: Comment preview URL
+        if: steps.pr.outputs.number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number('${{ steps.pr.outputs.number }}');
+            const previewUrl = `https://juliahealth.github.io/KomaMRI.jl/previews/PR${prNumber}/`;
+            const marker = '<!-- komamri-docs-preview-link -->';
+            const body = `${marker}\nPreview available: ${previewUrl}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find(comment =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  cleanup:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    name: Cleanup documentation preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Remove documentation preview
+        run: |
+          target="previews/PR${{ github.event.pull_request.number }}"
+          if [ -d "$target" ]; then
+            rm -rf "$target"
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "Remove preview for PR #${{ github.event.pull_request.number }} [skip ci]"
+            git push origin HEAD:gh-pages
+          else
+            echo "No preview directory to clean."
+          fi


### PR DESCRIPTION
## Summary
- add a standalone Docs Preview workflow
- comment a sticky docs preview URL when the `Documentation` job succeeds
- remove the PR preview directory from `gh-pages` when a PR closes

`CI.yml` is intentionally unchanged.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs-preview.yml"); puts "yaml ok"'`\n- `git diff --check origin/master...HEAD`