### PR TITLE
Fix docs preview workflow trigger

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     types:
       - closed
-  workflow_job:
+  workflow_run:
+    workflows:
+      - CI
     types:
       - completed
 
@@ -17,9 +19,9 @@ permissions:
 jobs:
   comment:
     if: >-
-      github.event_name == 'workflow_job' &&
-      github.event.workflow_job.name == 'Documentation' &&
-      github.event.workflow_job.conclusion == 'success'
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     name: Comment documentation preview URL
     runs-on: ubuntu-latest
     steps:
@@ -28,7 +30,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pullRequests = context.payload.workflow_job.pull_requests;
+            const pullRequests = context.payload.workflow_run.pull_requests;
             if (!pullRequests || pullRequests.length !== 1) {
               core.info(`Expected one pull request, found ${pullRequests?.length ?? 0}.`);
               return;


### PR DESCRIPTION
## Summary
- replace unsupported `workflow_job` trigger with `workflow_run` on CI completion
- keep preview cleanup on `pull_request.closed`

## Root cause
`workflow_job` is not a valid GitHub Actions workflow trigger, so GitHub rejected `.github/workflows/docs-preview.yml` before creating any jobs.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs-preview.yml"); puts "yaml ok"'`\n- `git diff --check`