### PR TITLE
Allow docs preview comments on PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -156,6 +156,9 @@ jobs:
     if: '!cancelled()'
     name: Documentation
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -12,6 +12,9 @@ jobs:
   cleanup:
     name: Cleanup documentation preview
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   comment:


### PR DESCRIPTION
## Summary
- give the Docs Preview workflow `pull-requests: write` so it can create/update PR comments
- serialize docs deploy and docs preview cleanup with one `gh-pages-deploy` concurrency group

## Root cause
The preview comment workflow found PR #769 and computed the preview URL, but GitHub rejected `POST /issues/769/comments` with `403 Resource not accessible by integration`. The response advertised accepted permissions as `issues=write; pull_requests=write`; the workflow only had `pull-requests: read`.

The cleanup workflow can also push `gh-pages` while the normal Documentation job is still building, which causes `git push ... HEAD:gh-pages` to fail with `fetch first`. Both gh-pages writers now share the same concurrency group.

## Testing
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "yaml ok"'`\n- `git diff --check`