### PR TITLE
Harden docs preview workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -156,9 +156,6 @@ jobs:
     if: '!cancelled()'
     name: Documentation
     runs-on: ubuntu-latest
-    concurrency:
-      group: gh-pages-deploy
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -12,9 +12,6 @@ jobs:
   cleanup:
     name: Cleanup documentation preview
     runs-on: ubuntu-latest
-    concurrency:
-      group: gh-pages-deploy
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -10,14 +10,13 @@ on:
       - master
 
 permissions:
+  actions: read
   issues: write
   pull-requests: write
 
 jobs:
   comment:
-    if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.event == 'pull_request'
     name: Comment documentation preview URL
     runs-on: ubuntu-latest
     steps:
@@ -41,6 +40,24 @@ jobs:
 
             if (!data.labels.some(label => label.name === 'documentation')) {
               core.info('Pull request does not have the documentation label.');
+              return;
+            }
+
+            if (data.head.sha !== context.payload.workflow_run.head_sha) {
+              core.info('Workflow run is not for the current pull request head.');
+              return;
+            }
+
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+              per_page: 100,
+            });
+
+            const docsJob = jobs.find(job => job.name === 'Documentation');
+            if (docsJob?.conclusion !== 'success') {
+              core.info(`Documentation job conclusion: ${docsJob?.conclusion ?? 'missing'}.`);
               return;
             }
 


### PR DESCRIPTION
Problem: the previous gh-pages concurrency lock was on the whole Documentation job. GitHub only keeps one pending job per concurrency group, so concurrent docs runs could cancel pending docs jobs instead of queueing them. The preview comment workflow also waited for the entire CI workflow to succeed, even though the relevant signal is the Documentation job.\n\nSolution: remove the broad docs/cleanup concurrency lock, and make the preview comment workflow check that the current PR head has a successful Documentation job before posting/updating the link.\n\nValidation: parsed the touched workflow YAML, ran git diff --check, and ran actionlint on CI.yml, docs-preview.yml, and docs-preview-cleanup.yml.