### PR TITLE
Separate docs preview deployment

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -179,15 +179,8 @@ jobs:
             using Documenter: doctest
             using KomaMRI
             doctest(KomaMRI)'
-      - if: ${{ !contains( github.event.pull_request.labels.*.name, 'documentation' ) }}
-        name: "Building documentation (docs/make.jl)"
+      - name: "Building documentation (docs/make.jl)"
         run: julia --project=docs docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-      - if: ${{ contains( github.event.pull_request.labels.*.name, 'documentation' ) }}
-        name: "Building documentation (docs/make.jl) - [PR] PUSH_PREVIEW"
-        run: julia --project=docs docs/make.jl push_preview
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -12,6 +12,9 @@ jobs:
   cleanup:
     name: Cleanup documentation preview
     runs-on: ubuntu-latest
+    concurrency:
+      group: docs-preview-gh-pages
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -11,14 +11,18 @@ on:
 
 permissions:
   actions: read
+  contents: write
   issues: write
   pull-requests: write
 
 jobs:
   comment:
     if: github.event.workflow_run.event == 'pull_request'
-    name: Comment documentation preview URL
+    name: Deploy documentation preview
     runs-on: ubuntu-latest
+    concurrency:
+      group: docs-preview-gh-pages
+      cancel-in-progress: false
     steps:
       - name: Find pull request
         id: pr
@@ -37,6 +41,16 @@ jobs:
               repo: context.repo.repo,
               pull_number: pr.number,
             });
+
+            if (data.state !== 'open') {
+              core.info('Pull request is not open.');
+              return;
+            }
+
+            if (data.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.info('Pull request is not from this repository.');
+              return;
+            }
 
             if (!data.labels.some(label => label.name === 'documentation')) {
               core.info('Pull request does not have the documentation label.');
@@ -62,6 +76,41 @@ jobs:
             }
 
             core.setOutput('number', pr.number);
+
+      - uses: actions/checkout@v6
+        if: steps.pr.outputs.number != ''
+        with:
+          ref: refs/pull/${{ steps.pr.outputs.number }}/merge
+          fetch-depth: 0
+
+      - uses: julia-actions/setup-julia@v2
+        if: steps.pr.outputs.number != ''
+        with:
+          version: '1'
+
+      - name: "Documentation dev environment setup"
+        if: steps.pr.outputs.number != ''
+        run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop([
+                PackageSpec(path=pwd(), subdir="."),
+                PackageSpec(path=pwd(), subdir="KomaMRIBase"),
+                PackageSpec(path=pwd(), subdir="KomaMRICore"),
+                PackageSpec(path=pwd(), subdir="KomaMRIFiles"),
+                PackageSpec(path=pwd(), subdir="KomaMRIPlots")
+            ])
+            Pkg.instantiate()'
+
+      - name: Build and deploy preview
+        if: steps.pr.outputs.number != ''
+        run: |
+          GITHUB_EVENT_NAME=pull_request \
+          GITHUB_REF=refs/pull/${{ steps.pr.outputs.number }}/merge \
+          julia --project=docs docs/make.jl push_preview
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
 
       - name: Comment preview URL
         if: steps.pr.outputs.number != ''

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -78,10 +78,13 @@ makedocs(;
     clean=false,
 )
 
-DocumenterVitepress.deploydocs(;
-    repo = "github.com/JuliaHealth/KomaMRI.jl",
-    target = joinpath(@__DIR__, "build"),
-    branch = "gh-pages",
-    devbranch = "master",
-    push_preview = true,
-)
+deploy_preview = "push_preview" in ARGS
+if get(ENV, "GITHUB_EVENT_NAME", "") == "push" || deploy_preview
+    DocumenterVitepress.deploydocs(;
+        repo = "github.com/JuliaHealth/KomaMRI.jl",
+        target = joinpath(@__DIR__, "build"),
+        branch = "gh-pages",
+        devbranch = "master",
+        push_preview = deploy_preview,
+    )
+end


### PR DESCRIPTION
Problem: PR docs CI was deploying previews directly to the shared `gh-pages` branch, so concurrent preview writes could reject with `fetch first` and fail the required Documentation check.

Solution: make `docs/make.jl` deploy only on `push` or explicit `push_preview`; have PR CI only build docs; move PR preview deployment/commenting into `Docs Preview` after a successful Documentation job. Preview deploy/cleanup now share one non-CI concurrency group.

Validation: `actionlint` on touched workflows; YAML parse; `git diff --check`; `docs/make.jl` parse check.