### PR TITLE
Fix CLI world age dispatch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KomaMRI"
 uuid = "6a340f8b-2cdf-4c04-99be-4953d9b66d0a"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Carlos Castillo Passi <cncastillo@uc.cl>"]
 
 [workspace]

--- a/src/KomaCLI.jl
+++ b/src/KomaCLI.jl
@@ -289,7 +289,7 @@ end
 function run_cli(args)
     opts = parse_cli_args(args, load_cli_preferences!(CLIOptions()))
     load_cli_backend!(opts)
-    return run_cli(opts)
+    return Base.invokelatest(run_cli, opts)
 end
 
 function run_cli(opts::CLIOptions)


### PR DESCRIPTION
## Summary
- dispatch CLI execution through `Base.invokelatest` after backend loading to avoid world age issues

## Tests
- Not run, per request.