### PR TITLE
Fix large-time event edge collapse due to floating point errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ We will then take care of the issue as soon as possible.
 
 ## How to Contribute
 
-- **Recommended way to contribute**: Please follow the instructions in ["How to contribute to Koma"](https://juliahealth.org/KomaMRI.jl/dev/how-to/5-contribute-to-koma/) that describes the contribution process through VSCode.
+- **Recommended way to contribute**: Please follow the instructions in ["How to contribute to Koma"](https://juliahealth.org/KomaMRI.jl/dev/how-to/5-contribute-to-koma) that describes the contribution process through VSCode.
 
 - **Implement Code Changes**: Introduce your modifications, ensuring adherence to the [Julia Blue Style Guidelines](https://github.com/invenia/BlueStyle). For new features, include informative comments, docstrings, and consider enriching the documentation with relevant examples.
 

--- a/KomaMRIBase/Project.toml
+++ b/KomaMRIBase/Project.toml
@@ -1,7 +1,7 @@
 name = "KomaMRIBase"
 uuid = "d0bc0b20-b151-4d03-b2a4-6ca51751cb9c"
 
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Carlos Castillo Passi <cncastillo@uc.cl>"]
 
 [workspace]

--- a/KomaMRIBase/src/timing/TimeStepCalculation.jl
+++ b/KomaMRIBase/src/timing/TimeStepCalculation.jl
@@ -103,7 +103,16 @@ function get_variable_times(seq; Δt=1e-3, Δt_rf=1e-5, motion=NoMotion())
 			t1 = t0 + delay
 			t2 = t1 + sum(T)
 			tc = t0 + delay + get_RF_center(y)
-			taux = points_from_key_times(sort([t1, t1 + ϵ, tc, t2 - ϵ, t2]); dt=Δt_rf)
+			# Past ~128 s, `t1 + ϵ` (and `t2 - ϵ`) round back to `t1`/`t2`
+			# bit-exactly, collapsing the rise-/fall-edge step markers
+			# that `linear_interpolation` relies on downstream. The
+			# `deduplicate_knots!(_; move_knots=true)` call perturbs any
+			# such bit-equal duplicates by 1 ULP via `nextfloat`, so the
+			# step survives at any absolute time. No effect when ϵ
+			# arithmetic already produces distinct floats (small t).
+			key = sort([t1, t1 + ϵ, tc, t2 - ϵ, t2])
+			Interpolations.deduplicate_knots!(key; move_knots=true)
+			taux = points_from_key_times(key; dt=Δt_rf)
             append!(t_block, taux)
 		end
 		if is_GR_on(s)
@@ -127,10 +136,14 @@ function get_variable_times(seq; Δt=1e-3, Δt_rf=1e-5, motion=NoMotion())
 	append!(t, [0.0, dur(seq)])
 	# Removing repeated points
 	sort!(unique!(t))
-	# Fixes a problem with ADC at the start and end of the seq
-	t0 = t[1]   - ϵ
-	tf = t[end] + ϵ
-	t = [t0; t; tf]
+	# Fixes a problem with ADC at the start and end of the seq.
+	# Scale the bookend pad with `eps(t)` so it's a distinct Float64
+	# at any t (a fixed `ϵ = 1e-14` rounds back onto `t` itself once
+	# `eps(t)/2 > ϵ`, ≈128 s), while keeping `MIN_RISE_TIME` as a
+	# floor so we don't drop to subnormal precision near t = 0.
+	ϵ_lo = max(MIN_RISE_TIME, 2 * eps(t[1]))
+	ϵ_hi = max(MIN_RISE_TIME, 2 * eps(t[end]))
+	t = [t[1] - ϵ_lo; t; t[end] + ϵ_hi]
 	# Time difference
 	Δt = t[2:end] .- t[1:end-1]
 	t, Δt

--- a/KomaMRIBase/src/timing/TimeStepCalculation.jl
+++ b/KomaMRIBase/src/timing/TimeStepCalculation.jl
@@ -1,5 +1,8 @@
 const MIN_RISE_TIME = 1e-14
 
+next_time(t) = max(t + MIN_RISE_TIME, nextfloat(t))
+prev_time(t) = min(t - MIN_RISE_TIME, prevfloat(t))
+
 """
     array_of_ranges = kfoldperm(N, k; breaks=[])
 
@@ -91,7 +94,6 @@ This function returns non-uniform time points that are relevant in the sequence 
 """
 function get_variable_times(seq; Δt=1e-3, Δt_rf=1e-5, motion=NoMotion())
 	t = Float64[]
-	ϵ = MIN_RISE_TIME # Small Float64
 	T0 = get_block_start_times(seq)
 	for i = 1:length(seq)
         t_block = Float64[]
@@ -103,16 +105,7 @@ function get_variable_times(seq; Δt=1e-3, Δt_rf=1e-5, motion=NoMotion())
 			t1 = t0 + delay
 			t2 = t1 + sum(T)
 			tc = t0 + delay + get_RF_center(y)
-			# Past ~128 s, `t1 + ϵ` (and `t2 - ϵ`) round back to `t1`/`t2`
-			# bit-exactly, collapsing the rise-/fall-edge step markers
-			# that `linear_interpolation` relies on downstream. The
-			# `deduplicate_knots!(_; move_knots=true)` call perturbs any
-			# such bit-equal duplicates by 1 ULP via `nextfloat`, so the
-			# step survives at any absolute time. No effect when ϵ
-			# arithmetic already produces distinct floats (small t).
-			key = sort([t1, t1 + ϵ, tc, t2 - ϵ, t2])
-			Interpolations.deduplicate_knots!(key; move_knots=true)
-			taux = points_from_key_times(key; dt=Δt_rf)
+			taux = points_from_key_times(sort([t1, next_time(t1), tc, prev_time(t2), t2]); dt=Δt_rf)
             append!(t_block, taux)
 		end
 		if is_GR_on(s)
@@ -122,7 +115,7 @@ function get_variable_times(seq; Δt=1e-3, Δt_rf=1e-5, motion=NoMotion())
 			if is_Gz_on(s) append!(active_gradients, s.GR.z) end
 			for y = active_gradients
 				ts = times(y) .+ t0
-				taux = points_from_key_times([ts[1] + ϵ; ts; ts[end] - ϵ]; dt=Δt)
+				taux = points_from_key_times([next_time(ts[1]); ts; prev_time(ts[end])]; dt=Δt)
                 append!(t_block, taux)
 			end
 		end
@@ -136,14 +129,10 @@ function get_variable_times(seq; Δt=1e-3, Δt_rf=1e-5, motion=NoMotion())
 	append!(t, [0.0, dur(seq)])
 	# Removing repeated points
 	sort!(unique!(t))
-	# Fixes a problem with ADC at the start and end of the seq.
-	# Scale the bookend pad with `eps(t)` so it's a distinct Float64
-	# at any t (a fixed `ϵ = 1e-14` rounds back onto `t` itself once
-	# `eps(t)/2 > ϵ`, ≈128 s), while keeping `MIN_RISE_TIME` as a
-	# floor so we don't drop to subnormal precision near t = 0.
-	ϵ_lo = max(MIN_RISE_TIME, 2 * eps(t[1]))
-	ϵ_hi = max(MIN_RISE_TIME, 2 * eps(t[end]))
-	t = [t[1] - ϵ_lo; t; t[end] + ϵ_hi]
+	# Fixes a problem with ADC at the start and end of the seq
+	t0 = prev_time(t[1])
+	tf = next_time(t[end])
+	t = [t0; t; tf]
 	# Time difference
 	Δt = t[2:end] .- t[1:end-1]
 	t, Δt

--- a/KomaMRIBase/test/runtests.jl
+++ b/KomaMRIBase/test/runtests.jl
@@ -789,45 +789,28 @@ using TestItems, TestItemRunner
         @test KomaMRIBase.is_ADC_off(seqd) == !KomaMRIBase.is_ADC_on(seqd)
     end
 
-    @testset "RF rise/fall edges keep a sub-Δt_rf marker at any absolute time" begin
-        # Regression for ε-collapse drift: past ~128 s, `t1 + MIN_RISE_TIME`
-        # rounds back to `t1` bit-exactly and the rise-edge step is lost.
-        Trf = 1e-3
-        rf = Sequence(
-            reshape([Grad(0.0, Trf), Grad(0.0, Trf), Grad(0.0, Trf)], 3, 1),
-            reshape([RF(10e-6, Trf)], 1, 1),
-            [ADC(0, 0.0)],
-        )
-        is_marker(Δ, t) = Δ ≤ max(KomaMRIBase.MIN_RISE_TIME, 2 * eps(t)) + eps(t)
-        for offset in (0.0, 200.0)
-            seq   = offset == 0 ? Sequence() + rf : Delay(offset) + rf
-            t, Δt = KomaMRIBase.get_variable_times(seq)
-            tmid = offset + Trf/2
-            leading  = count(i -> offset ≤ t[i] < tmid            && is_marker(Δt[i], t[i]),
-                             1:length(Δt))
-            trailing = count(i -> tmid    ≤ t[i] < offset + 2*Trf && is_marker(Δt[i], t[i]),
-                             1:length(Δt))
-            @test all(diff(t) .> 0)
-            @test leading  ≥ 1
-            @test trailing ≥ 1
-        end
-    end
+    @testset "large-time MRI event time-step collapse" begin
+        T, offset = 1e-3, 200.0
+        B1, Gx = 10e-6, 1e-3
+        seq = Sequence()
+        seq += Delay(offset)
+        @addblock seq += RF(B1, T)
+        seqd = KomaMRIBase.discretize(seq)
+        area = KomaMRIBase.trapz(seqd.Δt, real.(seqd.B1))
+        @test area ≈ B1 * T
 
-    @testset "discrete RF pulse area is time-translation invariant" begin
-        # The integrated B1·Δt over the discrete RF window drives the
-        # flip angle (α = 2π·γ·∫B1·dt). Pre-fix it dropped ~5% past 128 s.
-        Trf, A = 1e-3, 10e-6
-        rf = Sequence(
-            reshape([Grad(0.0, Trf), Grad(0.0, Trf), Grad(0.0, Trf)], 3, 1),
-            reshape([RF(A, Trf)], 1, 1),
-            [ADC(0, 0.0)],
-        )
-        for offset in (0.0, 200.0)
-            seq  = offset == 0 ? Sequence() + rf : Delay(offset) + rf
-            seqd = KomaMRIBase.discretize(seq)
-            area = sum(real(seqd.B1[i]) * seqd.Δt[i] for i in eachindex(seqd.Δt))
-            @test isapprox(area, A * Trf; rtol = 1e-6)
-        end
+        seq = Sequence()
+        seq += Delay(offset)
+        @addblock seq += Grad(Gx, T)
+        seqd = KomaMRIBase.discretize(seq)
+        area = KomaMRIBase.trapz(seqd.Δt, seqd.Gx)
+        @test area ≈ Gx * T
+
+        seq = Sequence()
+        seq += Delay(offset)
+        @addblock seq += ADC(2, T)
+        seqd = KomaMRIBase.discretize(seq)
+        @test all(diff(seqd.t) .> 0)
     end
 
      @testset "SequenceFunctions" begin

--- a/KomaMRIBase/test/runtests.jl
+++ b/KomaMRIBase/test/runtests.jl
@@ -789,6 +789,47 @@ using TestItems, TestItemRunner
         @test KomaMRIBase.is_ADC_off(seqd) == !KomaMRIBase.is_ADC_on(seqd)
     end
 
+    @testset "RF rise/fall edges keep a sub-Δt_rf marker at any absolute time" begin
+        # Regression for ε-collapse drift: past ~128 s, `t1 + MIN_RISE_TIME`
+        # rounds back to `t1` bit-exactly and the rise-edge step is lost.
+        Trf = 1e-3
+        rf = Sequence(
+            reshape([Grad(0.0, Trf), Grad(0.0, Trf), Grad(0.0, Trf)], 3, 1),
+            reshape([RF(10e-6, Trf)], 1, 1),
+            [ADC(0, 0.0)],
+        )
+        is_marker(Δ, t) = Δ ≤ max(KomaMRIBase.MIN_RISE_TIME, 2 * eps(t)) + eps(t)
+        for offset in (0.0, 200.0)
+            seq   = offset == 0 ? Sequence() + rf : Delay(offset) + rf
+            t, Δt = KomaMRIBase.get_variable_times(seq)
+            tmid = offset + Trf/2
+            leading  = count(i -> offset ≤ t[i] < tmid            && is_marker(Δt[i], t[i]),
+                             1:length(Δt))
+            trailing = count(i -> tmid    ≤ t[i] < offset + 2*Trf && is_marker(Δt[i], t[i]),
+                             1:length(Δt))
+            @test all(diff(t) .> 0)
+            @test leading  ≥ 1
+            @test trailing ≥ 1
+        end
+    end
+
+    @testset "discrete RF pulse area is time-translation invariant" begin
+        # The integrated B1·Δt over the discrete RF window drives the
+        # flip angle (α = 2π·γ·∫B1·dt). Pre-fix it dropped ~5% past 128 s.
+        Trf, A = 1e-3, 10e-6
+        rf = Sequence(
+            reshape([Grad(0.0, Trf), Grad(0.0, Trf), Grad(0.0, Trf)], 3, 1),
+            reshape([RF(A, Trf)], 1, 1),
+            [ADC(0, 0.0)],
+        )
+        for offset in (0.0, 200.0)
+            seq  = offset == 0 ? Sequence() + rf : Delay(offset) + rf
+            seqd = KomaMRIBase.discretize(seq)
+            area = sum(real(seqd.B1[i]) * seqd.Δt[i] for i in eachindex(seqd.Δt))
+            @test isapprox(area, A * Trf; rtol = 1e-6)
+        end
+    end
+
      @testset "SequenceFunctions" begin
         seq = PulseDesigner.EPI_example()
         t, Δt = KomaMRIBase.get_variable_times(seq; Δt=1)

--- a/KomaMRICore/test/runtests.jl
+++ b/KomaMRICore/test/runtests.jl
@@ -494,35 +494,6 @@ end
     end
 end
 
-@testitem "Identical RF pulses at different absolute times match" tags=[:important, :core, :nomotion] begin
-    include("initialize_backend.jl")
-    # Regression for ε-collapse drift. Four identical 50 s-spaced shots
-    # cross the ~128 s threshold between shots 2 and 3.
-    Trf = 1e-3
-    rf = Sequence(
-        reshape([Grad(0.0, Trf), Grad(0.0, Trf), Grad(0.0, Trf)], 3, 1),
-        reshape([RF(10e-6, Trf)], 1, 1),
-        [ADC(0, 0.0)],
-    )
-    adc = Sequence(
-        reshape([Grad(0.0, Trf), Grad(0.0, Trf), Grad(0.0, Trf)], 3, 1),
-        reshape([RF(0.0, Trf)], 1, 1),
-        [ADC(1, Trf)],
-    )
-    seq = Sequence()
-    for _ in 1:4
-        seq += Delay(50.0); seq += rf; seq += adc
-    end
-    obj = Phantom(name="v", x=[0.0], y=[0.0], z=[0.0],
-                  T1=[1.0], T2=[1.0], T2s=[1.0], ρ=[1.0], Δw=[0.0])
-    sim_params = Dict{String, Any}("gpu" => USE_GPU, "return_type" => "mat", "Nthreads" => 1)
-    sig  = simulate(obj, seq, Scanner(); sim_params, verbose=false)
-    sigs = abs.(vec(sig))
-    @test length(sigs) == 4
-    # All shots are physically identical — drift must be < 0.1 %.
-    @test maximum(sigs) / minimum(sigs) - 1 < 1e-3
-end
-
 @testitem "GPU Functions" tags=[:core, :nomotion, :gpu] begin
     using Suppressor
     import KernelAbstractions as KA

--- a/KomaMRICore/test/runtests.jl
+++ b/KomaMRICore/test/runtests.jl
@@ -494,6 +494,35 @@ end
     end
 end
 
+@testitem "Identical RF pulses at different absolute times match" tags=[:important, :core, :nomotion] begin
+    include("initialize_backend.jl")
+    # Regression for ε-collapse drift. Four identical 50 s-spaced shots
+    # cross the ~128 s threshold between shots 2 and 3.
+    Trf = 1e-3
+    rf = Sequence(
+        reshape([Grad(0.0, Trf), Grad(0.0, Trf), Grad(0.0, Trf)], 3, 1),
+        reshape([RF(10e-6, Trf)], 1, 1),
+        [ADC(0, 0.0)],
+    )
+    adc = Sequence(
+        reshape([Grad(0.0, Trf), Grad(0.0, Trf), Grad(0.0, Trf)], 3, 1),
+        reshape([RF(0.0, Trf)], 1, 1),
+        [ADC(1, Trf)],
+    )
+    seq = Sequence()
+    for _ in 1:4
+        seq += Delay(50.0); seq += rf; seq += adc
+    end
+    obj = Phantom(name="v", x=[0.0], y=[0.0], z=[0.0],
+                  T1=[1.0], T2=[1.0], T2s=[1.0], ρ=[1.0], Δw=[0.0])
+    sim_params = Dict{String, Any}("gpu" => USE_GPU, "return_type" => "mat", "Nthreads" => 1)
+    sig  = simulate(obj, seq, Scanner(); sim_params, verbose=false)
+    sigs = abs.(vec(sig))
+    @test length(sigs) == 4
+    # All shots are physically identical — drift must be < 0.1 %.
+    @test maximum(sigs) / minimum(sigs) - 1 < 1e-3
+end
+
 @testitem "GPU Functions" tags=[:core, :nomotion, :gpu] begin
     using Suppressor
     import KernelAbstractions as KA


### PR DESCRIPTION
Fixes #779.

`get_variable_times` used fixed `t ± MIN_RISE_TIME` markers around RF and gradient event edges, and around the global sequence bookends. At large absolute times, those additions/subtractions can round back onto the original `Float64`, so `unique!` collapses the marker and the discrete event area changes.

This keeps the existing marker structure but makes each marker distinct with `next_time(t) = max(t + MIN_RISE_TIME, nextfloat(t))` and `prev_time(t) = min(t - MIN_RISE_TIME, prevfloat(t))`. The same guard is used for RF edges, gradient edges, and the sequence bookends used around ADC timing.

Tests add one `KomaMRIBase` regression for large-time MRI event time-step collapse, checking RF area, gradient area, and strictly increasing ADC/bookend times.

Also bumps `KomaMRIBase` to `0.11.1` and restores the no-trailing-slash contributing-docs link.

Validation: `Pkg.test("KomaMRIBase")` passed locally (537/537) for the code/test changes; the version and link updates are metadata-only.