### PR TITLE
Fix zero-amplitude Pulseq RF import

### DIFF
--- a/KomaMRIFiles/Project.toml
+++ b/KomaMRIFiles/Project.toml
@@ -1,7 +1,7 @@
 name = "KomaMRIFiles"
 uuid = "fcf631a6-1c7e-4e88-9e64-b8888386d9dc"
 
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Carlos Castillo Passi <cncastillo@uc.cl>"]
 
 [workspace]

--- a/KomaMRIFiles/src/Sequence/pulseq/ReadPulseq.jl
+++ b/KomaMRIFiles/src/Sequence/pulseq/ReadPulseq.jl
@@ -918,6 +918,8 @@ function get_RF(r::PulseqRFEvent, shapeLibrary, rf_raster_time; use=get_RF_use_f
     delay = r.delay + first_sample_offset
     freq = r.freq
     phase = r.phase
+    # Some Pulseq writers emit zero-amplitude RFs.
+    iszero(amplitude) && return RF(0.0, 0.0, freq, 0.0; ϕ=phase, use)
     #Amplitude and phase waveforms
     if amplitude != 0 && mag_id != 0
         rfA = decompress_shape(shapeLibrary[mag_id]...)

--- a/KomaMRIFiles/test/runtests.jl
+++ b/KomaMRIFiles/test/runtests.jl
@@ -508,6 +508,26 @@ end
         seq = read_seq(joinpath(@__DIR__, "test_files/pulseq/read_comparison/v1.2/epi_JEMRIS.seq"); verbose=false)
         @test all(rf -> !is_RF_on(rf) || !isnothing(rf.center), vec(seq.RF))
     end
+    @testset "Zero-amplitude Pulseq RF" begin
+        mktempdir() do dir
+            filename = joinpath(dir, "zero-rf.seq")
+            Δt_rf = KomaMRIFiles.DEFAULT_RASTER.RadiofrequencyRasterTime
+            seq = Sequence()
+            addblock!(seq, RF(ComplexF64[1.0, 0.5, 1.0], [Δt_rf, Δt_rf], 0.0, Δt_rf), Duration(10Δt_rf))
+            write_seq(seq, filename; verbose=false)
+
+            lines = readlines(filename)
+            i = findfirst(line -> startswith(line, "1 ") && contains(line, " 1 2 3 "), lines)
+            fields = split(lines[i])
+            # Some Pulseq writers emit zero-amplitude RFs. Koma does not, so this test makes one manually.
+            fields[2] = "0.0"
+            lines[i] = join(fields, " ")
+            write(filename, join(lines, "\n"))
+
+            seq = read_seq(filename; verbose=false)
+            @test !is_RF_on(seq.RF[1, 1])
+        end
+    end
     @testset "Trapezoidal gradient writes without shape libraries" begin
         trap = Sequence([Grad(1e-3, 2e-3, 1e-3, 1e-3, 0.5e-3)])
         libs = pulseq_data_after_write(trap, "trap.seq").libraries

--- a/KomaMRIFiles/test/runtests.jl
+++ b/KomaMRIFiles/test/runtests.jl
@@ -516,10 +516,10 @@ end
             addblock!(seq, RF(ComplexF64[1.0, 0.5, 1.0], [Δt_rf, Δt_rf], 0.0, Δt_rf), Duration(10Δt_rf))
             write_seq(seq, filename; verbose=false)
 
+            # Some Pulseq writers emit zero-amplitude RFs. Koma does not, so this test makes one manually.
             lines = readlines(filename)
             i = findfirst(line -> startswith(line, "1 ") && contains(line, " 1 2 3 "), lines)
             fields = split(lines[i])
-            # Some Pulseq writers emit zero-amplitude RFs. Koma does not, so this test makes one manually.
             fields[2] = "0.0"
             lines[i] = join(fields, " ")
             write(filename, join(lines, "\n"))


### PR DESCRIPTION
Fixes #778.

Some Pulseq writers emit zero-amplitude RF events. The reader now treats those RF events as off instead of decoding the referenced time shape into an invalid zero-amplitude RF waveform.

This also bumps KomaMRIFiles to 0.10.4.

Validation:
- `Pkg.test("KomaMRIFiles")` passed locally (24455/24455)
- The uploaded `problem_rf.txt` from #778 loads successfully (`blocks=500`, `rf104_on=false`)