### PR TITLE
Fix Bloch precession Bz initialization

### DIFF
--- a/KomaMRICore/Project.toml
+++ b/KomaMRICore/Project.toml
@@ -1,7 +1,7 @@
 name = "KomaMRICore"
 uuid = "4baa4f4d-2ae9-40db-8331-a7d1080e3f4e"
 authors = ["Carlos Castillo Passi <cncastillo@uc.cl>"]
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 AcceleratedKernels = "6a4ca0a5-0e36-4168-a932-d9be78d558f1"

--- a/KomaMRICore/src/simulation/SimMethods/Bloch/cpu/BlochCPU.jl
+++ b/KomaMRICore/src/simulation/SimMethods/Bloch/cpu/BlochCPU.jl
@@ -65,6 +65,8 @@ function run_spin_precession!(
     fill!(ϕ, zero(T))
     block_time = zero(T)
     sample = 1
+    x, y, z = get_spin_coords(p.motion, p.x, p.y, p.z, seq.t[1])
+    @. Bz_old = x * seq.Gx[1] + y * seq.Gy[1] + z * seq.Gz[1] + ΔBz
     #Simulation
     for i in eachindex(seq.Δt)
         #Motion

--- a/KomaMRICore/test/runtests.jl
+++ b/KomaMRICore/test/runtests.jl
@@ -315,25 +315,25 @@ end
     Trf = Tadc
     B1 = 2e-6 * (Tadc / Trf)
     rf_phase = [0, π/2]
+    Gx = 25e-3
     Nadc = 6
     # Phantom params
     M0 = 1.0
     T1 = 1000e-3
     T2 = 20e-3
     Δw = 2π * 100
+    x = 1e-2
     
     ## Solving using KomaMRI
     seq = Sequence()
-    seq += ADC(Nadc, Tadc)
-    seq += RF(B1 .* cis(rf_phase[1]), Trf)
-    seq += ADC(Nadc, Tadc)
+    @addblock seq += ADC(Nadc, Tadc)
+    @addblock seq += (RF(B1 .* cis(rf_phase[1]), Trf), x=Grad(Gx, Trf))
+    @addblock seq += ADC(Nadc, Tadc)
     # This introduces an RF-ADC overlap!!!
-    seq += RF(B1 .* cis(rf_phase[2]), Trf)
-    seq.ADC[4] = ADC(Nadc, 2Tadc, Trf/2)
-    seq.DUR[4] = max(seq.DUR[4], dur(seq.RF[4]), dur(seq.ADC[4]))
+    @addblock seq += (RF(B1 .* cis(rf_phase[2]), Trf), ADC(Nadc, 2Tadc, Trf/2))
 
     sys = Scanner()
-    obj = Phantom(x = [0.], ρ = [M0], T1 = [T1], T2 = [T2], Δw = [Δw])
+    obj = Phantom(x = [x], ρ = [M0], T1 = [T1], T2 = [T2], Δw = [Δw])
 
     mxy_diffeq = diffeq_signal(seq, obj)
 


### PR DESCRIPTION
Fixes #784

## Summary
- initialize CPU Bloch precession Bz from the block start instead of relying on cached state from previous blocks
- add an off-center RF accuracy case with an RF-block gradient
- bump KomaMRICore to 0.11.1

## Tests
- Pkg.test("KomaMRICore")