### PR TITLE
Fix link to motion docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,7 +36,7 @@ features:
   - icon: 🌊
     title: Dynamic Motion Models
     details: Simulate static and dynamic phantoms. Model motion and complex spin trajectories with reusable HDF5 phantom files.
-    link: /explanation/2-motion
+    link: /explanation/gen-2-motion
 
   - icon: 🖥️
     title: Interactive GUI


### PR DESCRIPTION
Fixes this button leading to a 404 error:

<img width="458" height="634" alt="Screenshot 2026-06-10 at 12 35 37" src="https://github.com/user-attachments/assets/abe43b29-dc47-494e-91ae-f4909f50f2bb" />
