### PR TITLE
Clean up GPU extension compatibility

### DIFF
--- a/KomaMRICore/Project.toml
+++ b/KomaMRICore/Project.toml
@@ -38,7 +38,7 @@ ProgressMeter = "1"
 Reexport = "1"
 ThreadsX = "0.1"
 julia = "1.10"
-oneAPI = "1, 2"
+oneAPI = "2.4"
 
 [workspace]
 projects = ["test"]

--- a/KomaMRICore/Project.toml
+++ b/KomaMRICore/Project.toml
@@ -1,7 +1,7 @@
 name = "KomaMRICore"
 uuid = "4baa4f4d-2ae9-40db-8331-a7d1080e3f4e"
 authors = ["Carlos Castillo Passi <cncastillo@uc.cl>"]
-version = "0.11.2"
+version = "0.11.3"
 
 [deps]
 AcceleratedKernels = "6a4ca0a5-0e36-4168-a932-d9be78d558f1"

--- a/KomaMRICore/ext/KomaMetalExt.jl
+++ b/KomaMRICore/ext/KomaMetalExt.jl
@@ -11,7 +11,7 @@ KomaMRICore.isfunctional(::MetalBackend) = Metal.functional()
 KomaMRICore.supports_warp_reduction(::MetalBackend) = true
 KomaMRICore.set_device!(::MetalBackend, device_index::Integer) = device_index == 1 || @warn "Metal does not support multiple gpu devices. Ignoring the device setting."
 KomaMRICore.set_device!(::MetalBackend, dev::Metal.MTLDevice) = Metal.device!(dev)
-KomaMRICore.device_name(::MetalBackend) = String(Metal.current_device().name)
+KomaMRICore.device_name(::MetalBackend) = String(Metal.device().name)
 
 @inline function KomaMRICore.shfl_down(val, offset)
     Metal.simd_shuffle_down(val, offset) 

--- a/KomaMRICore/ext/KomaoneAPIExt.jl
+++ b/KomaMRICore/ext/KomaoneAPIExt.jl
@@ -17,45 +17,6 @@ function KomaMRICore._print_devices(::oneAPIBackend)
     @info "$(length(oneAPI.devices())) oneAPI capable device(s)." devices...
 end
 
-#Temporary workaround since oneAPI.jl (similar to Metal) does not support some array operations
-#Once run_spin_excitation! and run_spin_precession! are kernel-based, this code can be removed
-Base.cumsum(x::oneVector{T}) where T = convert(oneVector{T}, cumsum(KomaMRICore.cpu(x)))
-Base.findall(x::oneVector{Bool}) = convert(oneVector, findall(KomaMRICore.cpu(x)))
-
-using KernelAbstractions: @index, @kernel, @Const, synchronize
-
-"""Naive cumsum implementation for matrix, parallelizes along the first dimension"""
-Base.cumsum(A::oneArray{T}; dims) where T = begin
-    dims == 2 || @error "oneAPI cumsum implementation only supports keyword argument dims=2"
-    backend = oneAPIBackend()
-    B = similar(A)
-    cumsum_kernel = naive_cumsum!(backend)
-    cumsum_kernel(B, A, ndrange=size(A,1))
-    synchronize(backend)
-    return B
-end
-
-Base.cumsum!(B::oneArray{T}, A::oneArray{T}; dims) where T = begin
-    dims == 2 || @error "oneAPI cumsum implementation only supports keyword argument dims=2"
-    backend = oneAPIBackend()
-    cumsum_kernel = naive_cumsum!(backend)
-    cumsum_kernel(B, A, ndrange=size(A,1))
-    synchronize(backend)
-end
-
-## COV_EXCL_START
-@kernel function naive_cumsum!(B, @Const(A))
-    i = @index(Global)
-    T = eltype(A)
-
-    cur_val = zero(T)
-    for k ∈ 1:size(A, 2)
-        @inbounds cur_val += A[i, k]
-        @inbounds B[i, k] = cur_val
-    end
-end
-## COV_EXCL_STOP
-
 function __init__()
     push!(KomaMRICore.LOADED_BACKENDS[], oneAPIBackend())
     @warn "oneAPI support is experimental and does not support all array operations used by KomaMRI. GPU performance may be slower than expected"


### PR DESCRIPTION
## Summary
- replace deprecated Metal device-name lookup with `Metal.device()`
- require oneAPI 2.4+ and rely on upstream native `cumsum`/`findall` support
- remove obsolete Koma oneAPI fallback methods that caused extension precompile method-overwrite errors

## Validation
- `git diff --check`

Julia/backend tests were not run locally; this PR is labeled `run-gpu-ci` for Buildkite GPU coverage.
