### PR TITLE
Improve docs workflow concurrency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,8 +157,8 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     concurrency:
-      group: docs-gh-pages
-      cancel-in-progress: false
+      group: docs-build-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -13,7 +13,7 @@ jobs:
     name: Cleanup documentation preview
     runs-on: ubuntu-latest
     concurrency:
-      group: docs-gh-pages
+      group: docs-preview-cleanup-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -21,8 +21,8 @@ jobs:
     name: Deploy documentation preview
     runs-on: ubuntu-latest
     concurrency:
-      group: docs-gh-pages
-      cancel-in-progress: false
+      group: docs-preview-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch || github.run_id }}
+      cancel-in-progress: true
     steps:
       - name: Find pull request
         id: pr


### PR DESCRIPTION
## Summary
- scope documentation CI concurrency to each PR or ref
- scope docs preview deployment and cleanup concurrency to each PR
- allow stale docs builds/previews to be superseded without canceling unrelated PRs

## Validation
- git diff --check
- parsed modified workflow YAML with Ruby YAML loader
- actionlint unavailable locally