### PR TITLE
Fix Plotly docs WebGL embedding

### DIFF
--- a/docs/EmbeddPlotlyJSSyncPlotLiterate.jl
+++ b/docs/EmbeddPlotlyJSSyncPlotLiterate.jl
@@ -44,12 +44,14 @@ function Base.show(io::IO, ::MIME"text/html", fig::PlotlyJS.SyncPlot)
     srcdoc = replace("""
         <!doctype html>
         <meta charset="utf-8">
+        <style>
+        html, body, iframe { margin: 0; width: 100%; height: 100%; border: 0; overflow: hidden; background: transparent; }
+        </style>
+        <iframe id="plot"></iframe>
         <script>
         const encoded = "$encoded";
-        const bytes = Uint8Array.from(atob(encoded), c => c.charCodeAt(0));
-        document.open();
-        document.write(new TextDecoder().decode(bytes));
-        document.close();
+        const html = new TextDecoder().decode(Uint8Array.from(atob(encoded), c => c.charCodeAt(0)));
+        document.getElementById("plot").srcdoc = html;
         </script>
         """, '&' => "&amp;", '"' => "&quot;", '<' => "&lt;", '>' => "&gt;")
     width = to_css_size(get(fig.plot.layout.fields, :width, nothing))

--- a/docs/EmbeddPlotlyJSSyncPlotLiterate.jl
+++ b/docs/EmbeddPlotlyJSSyncPlotLiterate.jl
@@ -8,7 +8,7 @@ to_css_size(x::AbstractString) = x
 to_css_size(::Nothing) = "100%"
 to_css_size(x) = throw(ArgumentError("Unsupported Plotly size type: $(typeof(x))"))
 
-# For CSS string sizes, keep the explicit size on the outer iframe only.
+# For CSS string sizes, keep the explicit size on the outer <object> only.
 # The inner Plotly HTML should stay at 100% to avoid double-scaling.
 layout_to_html_default_size!(fields, key::Symbol, value::AbstractString) = (pop!(fields, key, nothing); "100%")
 layout_to_html_default_size!(fields, key::Symbol, ::Nothing) = (pop!(fields, key, nothing); "100%")
@@ -41,26 +41,30 @@ function Base.show(io::IO, ::MIME"text/html", fig::PlotlyJS.SyncPlot)
     html = String(take!(html_buffer))
     html = replace(html, "<body>" => "<body style=\"margin:0;overflow:hidden;background:transparent;\">")
     encoded = base64encode(html)
-    srcdoc = replace("""
-        <!doctype html>
-        <meta charset="utf-8">
-        <style>
-        html, body, iframe { margin: 0; width: 100%; height: 100%; border: 0; overflow: hidden; background: transparent; }
-        </style>
-        <iframe id="plot"></iframe>
-        <script>
-        const encoded = "$encoded";
-        const html = new TextDecoder().decode(Uint8Array.from(atob(encoded), c => c.charCodeAt(0)));
-        document.getElementById("plot").srcdoc = html;
-        </script>
-        """, '&' => "&amp;", '"' => "&quot;", '<' => "&lt;", '>' => "&gt;")
+    onload = replace(
+        """
+        this.onload=null;
+        this.removeAttribute('onload');
+        const encoded=this.dataset.plotlyHtml;
+        this.removeAttribute('data-plotly-html');
+        const bytes=Uint8Array.from(atob(encoded),c=>c.charCodeAt(0));
+        const doc=this.contentDocument;
+        doc.open();
+        doc.write(new TextDecoder().decode(bytes));
+        doc.close();
+        """,
+        '&' => "&amp;",
+        '"' => "&quot;",
+        '<' => "&lt;",
+        '>' => "&gt;",
+    )
     width = to_css_size(get(fig.plot.layout.fields, :width, nothing))
     _, plot_height = size(fig)
     height = to_css_size(plot_height)
     write(
         io,
         """
-        <iframe srcdoc="$srcdoc" style="display:block;max-width:none;border:0;width:$width;height:$height;"></iframe>
+        <object type="text/html" data="about:blank" data-plotly-html="$encoded" onload="$onload" style="display:block;max-width:none;border:0;width:$width;height:$height;"></object>
         """,
     )
 end

--- a/docs/EmbeddPlotlyJSSyncPlotLiterate.jl
+++ b/docs/EmbeddPlotlyJSSyncPlotLiterate.jl
@@ -8,7 +8,7 @@ to_css_size(x::AbstractString) = x
 to_css_size(::Nothing) = "100%"
 to_css_size(x) = throw(ArgumentError("Unsupported Plotly size type: $(typeof(x))"))
 
-# For CSS string sizes, keep the explicit size on the outer <object> only.
+# For CSS string sizes, keep the explicit size on the outer iframe only.
 # The inner Plotly HTML should stay at 100% to avoid double-scaling.
 layout_to_html_default_size!(fields, key::Symbol, value::AbstractString) = (pop!(fields, key, nothing); "100%")
 layout_to_html_default_size!(fields, key::Symbol, ::Nothing) = (pop!(fields, key, nothing); "100%")
@@ -41,13 +41,24 @@ function Base.show(io::IO, ::MIME"text/html", fig::PlotlyJS.SyncPlot)
     html = String(take!(html_buffer))
     html = replace(html, "<body>" => "<body style=\"margin:0;overflow:hidden;background:transparent;\">")
     encoded = base64encode(html)
+    srcdoc = replace("""
+        <!doctype html>
+        <meta charset="utf-8">
+        <script>
+        const encoded = "$encoded";
+        const bytes = Uint8Array.from(atob(encoded), c => c.charCodeAt(0));
+        document.open();
+        document.write(new TextDecoder().decode(bytes));
+        document.close();
+        </script>
+        """, '&' => "&amp;", '"' => "&quot;", '<' => "&lt;", '>' => "&gt;")
     width = to_css_size(get(fig.plot.layout.fields, :width, nothing))
     _, plot_height = size(fig)
     height = to_css_size(plot_height)
     write(
         io,
         """
-        <object type="text/html" data="data:text/html;base64,$encoded" style="display:block;max-width:none;border:0;width:$width;height:$height;"></object>
+        <iframe srcdoc="$srcdoc" style="display:block;max-width:none;border:0;width:$width;height:$height;"></iframe>
         """,
     )
 end


### PR DESCRIPTION
## Summary
- keep Plotly docs figures embedded as `<object>` elements instead of moving plots to external generated assets
- keep the generated Plotly HTML payload base64-embedded in the final doc page
- avoid Chromium's overlong `data:` URL path by loading a tiny `about:blank` object and writing the decoded payload into that object document
- leave KomaMRIPlots trace generation unchanged, including `scattergl`

## Root cause
Issue #810 reports blank interactive plots in Chrome on the diffusion and RR variability tutorials. Those figures are large Plotly `scattergl` documents embedded as:

```html
<object data="data:text/html;base64,...">
```

That puts the entire generated Plotly document in the object's URL. In Chromium, the affected RR payload is already about 2.1 MB as base64, and the diffusion random-walk payload is much larger. Direct `data:` URL embeds around that size are blocked or blank in the in-app Chromium browser.

The fix keeps the base64 payload in the page, but stops using it as a URL. Each plot is emitted as an object whose URL is only `about:blank`; the base64 payload is stored in `data-plotly-html`, decoded on object load, written into the object's same-origin blank document, and then removed from the live DOM.

This avoids external plot files, avoids path issues after Documenter/VitePress generation, and does not replace `scattergl`.

Fixes #810.

## Validation
- `include("docs/make.jl")` from `julia --project=docs --threads=auto`
- served the final static site from `docs/build/1` with `uv run python -m http.server 8102 --bind 127.0.0.1 -d docs/build/1`
- verified `http://127.0.0.1:8102/assets/app.cN8YrZrc.js` returns `200`
- verified in the Codex in-app Chromium browser that `tutorial/gen-08-RRVariability.html` renders the formerly blank `scattergl` plot
- verified in the Codex in-app Chromium browser that `tutorial/gen-06-DiffusionMotion.html` renders the formerly blank `scattergl` plot
- checked that the generated objects remove `data-plotly-html` and `onload` from the live DOM after loading
