### PR TITLE
Apply ADC frequency offset compensation

### DIFF
--- a/KomaMRIBase/src/datatypes/sequence/ADC.jl
+++ b/KomaMRIBase/src/datatypes/sequence/ADC.jl
@@ -123,7 +123,7 @@ function get_adc_phase_compensation(seq)
     for i in 1:length(seq)
         adc = seq.ADC[i]
         if is_ADC_on(adc)
-            append!(phase, exp.(-1im .* (adc.ϕ .+ 2π * adc.Δf .* times(adc))))
+            append!(phase, cis.(-(adc.ϕ .+ 2π * adc.Δf .* times(adc))))
         end
     end
     return phase

--- a/KomaMRIBase/src/datatypes/sequence/ADC.jl
+++ b/KomaMRIBase/src/datatypes/sequence/ADC.jl
@@ -105,9 +105,9 @@ end
 """
     comp = get_adc_phase_compensation(seq)
 
-Returns an array of phase compensation factors, ``\\exp(-\\mathrm{i}\\varphi)``, which are
+Returns an array of phase compensation factors, ``\\exp(-\\mathrm{i}(\\varphi + 2\\pi \\Delta f t))``, which are
 used to compensate the acquired signal ``S`` by applying the operation
-``S_{\\mathrm{comp}} = S \\exp(-\\mathrm{i}\\varphi)`` after the simulation. This compensation
+``S_{\\mathrm{comp}} = S \\exp(-\\mathrm{i}(\\varphi + 2\\pi \\Delta f t))`` after the simulation. This compensation
 is necessary because the signal typically exhibits a phase offset of ``\\varphi`` following
 RF excitation with a phase of ``\\varphi``. Such pulses are commonly employed in sequences
 involving RF spoiling.
@@ -123,10 +123,7 @@ function get_adc_phase_compensation(seq)
     for i in 1:length(seq)
         adc = seq.ADC[i]
         if is_ADC_on(adc)
-            N = adc.N
-            ϕ = adc.ϕ
-            aux = ones(N) .* exp(-1im * ϕ)
-            append!(phase, aux)
+            append!(phase, exp.(-1im .* (adc.ϕ .+ 2π * adc.Δf .* times(adc))))
         end
     end
     return phase


### PR DESCRIPTION
## Summary
- include the ADC frequency offset term in `get_adc_phase_compensation`
- update the compensation docstring to describe `φ + 2πΔf t`

## Validation
- `Pkg.test("KomaMRIBase")` passed: 731/731 tests
- manual Koma Pulseq simulation sanity check with the provided TSE/FOV-shifted TSE sequences measured the expected `[50, 40] mm` shift
<img width="879" height="626" alt="image" src="https://github.com/user-attachments/assets/f5426a09-6c63-4292-b322-c39cda7dcbbd" />
