### PR TITLE
Hoist constants in GPU Bloch kernels

### DIFF
--- a/KomaMRICore/src/simulation/SimMethods/Bloch/gpu/ExcitationKernel.jl
+++ b/KomaMRICore/src/simulation/SimMethods/Bloch/gpu/ExcitationKernel.jl
@@ -47,6 +47,8 @@ end
     i_g = @index(Group, Linear)
     i = (i_g - 1u32) * UInt32(N) + i_l
 
+    B_to_ω = T(-2π * γ)
+    inv_γ = inv(T(γ))
     sig_group_r = @localmem T HAS_ADC ? (USE_WARP_REDUCTION ? 32 : N) : 1
     sig_group_i = @localmem T HAS_ADC ? (USE_WARP_REDUCTION ? 32 : N) : 1
 
@@ -58,6 +60,8 @@ end
     ΔBz = zero(T)
     T1 = T(1)
     T2 = T(1)
+    neg_inv_T1 = -one(T)
+    neg_inv_T2 = -one(T)
     x = zero(T)
     y = zero(T)
     z = zero(T)
@@ -72,6 +76,8 @@ end
         ρ = p_ρ[i]
         T1 = p_T1[i]
         T2 = p_T2[i]
+        neg_inv_T1 = -inv(T1)
+        neg_inv_T2 = -inv(T2)
         # Rotating frame -> RF frame
         # M * exp(-i * ψ)
         ψ_start = s_ψ[1]
@@ -83,7 +89,7 @@ end
         # Calculate initial B
         x, y, z = get_spin_coordinates(p_x, p_y, p_z, i, 1)
         Bx_0, By_0 = reim(s_B1[1])
-        Bz_0 = x * s_Gx[1] + y * s_Gy[1] + z * s_Gz[1] + ΔBz - s_Δf[1] / T(γ)
+        Bz_0 = x * s_Gx[1] + y * s_Gy[1] + z * s_Gz[1] + ΔBz - s_Δf[1] * inv_γ
     end
 
     ADC_idx = 1u32
@@ -94,18 +100,18 @@ end
                 x, y, z = get_spin_coordinates(p_x, p_y, p_z, i, s_idx)
             end
             Bx_1, By_1 = reim(s_B1[s_idx])
-            Bz_1 = (x * s_Gx[s_idx] + y * s_Gy[s_idx] + z * s_Gz[s_idx]) + ΔBz - s_Δf[s_idx] / T(γ)
+            Bz_1 = (x * s_Gx[s_idx] + y * s_Gy[s_idx] + z * s_Gz[s_idx]) + ΔBz - s_Δf[s_idx] * inv_γ
 
             Δt = s_Δt[s_idx - 1]
 
-            θx, θy, θz = rotation_vector(Bx_0, By_0, Bz_0, Bx_1, By_1, Bz_1, Δt, sim_method)
+            θx, θy, θz = rotation_vector(Bx_0, By_0, Bz_0, Bx_1, By_1, Bz_1, Δt, B_to_ω, sim_method)
             M_norm = mag_norm(T, Mxy_r, Mxy_i, Mz)
             Mxy_new_r, Mxy_new_i, Mz_new = rotate_magnetization(θx, θy, θz, Mxy_r, Mxy_i, Mz, T)
             Mxy_new_r, Mxy_new_i, Mz_new = restore_mag_norm(M_norm, Mxy_new_r, Mxy_new_i, Mz_new) # For reduced float precision only.
             
             # Relaxation
-            E1 = exp(-Δt / T1)
-            E2 = exp(-Δt / T2)
+            E1 = exp(Δt * neg_inv_T1)
+            E2 = exp(Δt * neg_inv_T2)
             Mxy_r = Mxy_new_r * E2
             Mxy_i = Mxy_new_i * E2
             Mz = Mz_new * E1 + ρ * (T(1) - E1)

--- a/KomaMRICore/src/simulation/SimMethods/Bloch/gpu/PrecessionKernel.jl
+++ b/KomaMRICore/src/simulation/SimMethods/Bloch/gpu/PrecessionKernel.jl
@@ -14,6 +14,7 @@
     i_g = @index(Group, Linear)
     i = (i_g - 1u32) * UInt32(N) + i_l
 
+    precession_scale = T(-π * γ)
     sig_group_r = @localmem T HAS_ADC ? (USE_WARP_REDUCTION ? 32 : N) : 1
     sig_group_i = @localmem T HAS_ADC ? (USE_WARP_REDUCTION ? 32 : N) : 1
     
@@ -50,7 +51,7 @@
             Δt = s_Δt[s_idx-1]
             t += Δt
             Bz_next = x * s_Gx[s_idx] + y * s_Gy[s_idx] + z * s_Gz[s_idx] + ΔBz
-            ϕ += (Bz_prev + Bz_next) * T(-π * γ) * Δt
+            ϕ += (Bz_prev + Bz_next) * precession_scale * Δt
         end
         # Acquire Signal
         if HAS_ADC && s_ADC[s_idx]

--- a/KomaMRICore/src/simulation/SimMethods/BlochMagnus/gpu/MagnusGLKernel.jl
+++ b/KomaMRICore/src/simulation/SimMethods/BlochMagnus/gpu/MagnusGLKernel.jl
@@ -14,6 +14,9 @@
     i_g = @index(Group, Linear)
     i = (i_g - 1u32) * UInt32(N) + i_l
 
+    B_to_ω = T(-2π * γ)
+    B_to_ω2_sqrt3 = B_to_ω * B_to_ω * sqrt(T(3))
+    inv_γ = inv(T(γ))
     sig_group_r = @localmem T HAS_ADC ? (USE_WARP_REDUCTION ? 32 : N) : 1
     sig_group_i = @localmem T HAS_ADC ? (USE_WARP_REDUCTION ? 32 : N) : 1
 
@@ -25,6 +28,8 @@
     ΔBz = zero(T)
     T1 = T(1)
     T2 = T(1)
+    neg_inv_T1 = -one(T)
+    neg_inv_T2 = -one(T)
     x = zero(T)
     y = zero(T)
     z = zero(T)
@@ -36,6 +41,8 @@
         ρ = p_ρ[i]
         T1 = p_T1[i]
         T2 = p_T2[i]
+        neg_inv_T1 = -inv(T1)
+        neg_inv_T2 = -inv(T2)
 
         ψ_start = s_ψ[1]
         if !iszero(ψ_start)
@@ -58,23 +65,25 @@
             x_plus, y_plus, z_plus = MOTION ? get_spin_coordinates(p_x, p_y, p_z, i, s_plus) : (x, y, z)
 
             Bx_minus, By_minus = reim(s_B1[s_minus])
-            Bz_minus = x_minus * s_Gx[s_minus] + y_minus * s_Gy[s_minus] + z_minus * s_Gz[s_minus] + ΔBz - s_Δf[s_minus] / T(γ)
+            Bz_minus = x_minus * s_Gx[s_minus] + y_minus * s_Gy[s_minus] + z_minus * s_Gz[s_minus] + ΔBz - s_Δf[s_minus] * inv_γ
             Bx_plus, By_plus = reim(s_B1[s_plus])
-            Bz_plus = x_plus * s_Gx[s_plus] + y_plus * s_Gy[s_plus] + z_plus * s_Gz[s_plus] + ΔBz - s_Δf[s_plus] / T(γ)
+            Bz_plus = x_plus * s_Gx[s_plus] + y_plus * s_Gy[s_plus] + z_plus * s_Gz[s_plus] + ΔBz - s_Δf[s_plus] * inv_γ
 
             Δt = s_Δt[s_idx] + s_Δt[s_minus] + s_Δt[s_plus]
             θx, θy, θz = rotation_vector(
                 Bx_minus, By_minus, Bz_minus,
                 Bx_plus, By_plus, Bz_plus,
                 Δt,
+                B_to_ω,
+                B_to_ω2_sqrt3,
                 sim_method,
             )
             M_norm = mag_norm(T, Mxy_r, Mxy_i, Mz)
             Mxy_new_r, Mxy_new_i, Mz_new = rotate_magnetization(θx, θy, θz, Mxy_r, Mxy_i, Mz, T)
             Mxy_new_r, Mxy_new_i, Mz_new = restore_mag_norm(M_norm, Mxy_new_r, Mxy_new_i, Mz_new) # For reduced float precision only.
 
-            E1 = exp(-Δt / T1)
-            E2 = exp(-Δt / T2)
+            E1 = exp(Δt * neg_inv_T1)
+            E2 = exp(Δt * neg_inv_T2)
             Mxy_r = Mxy_new_r * E2
             Mxy_i = Mxy_new_i * E2
             Mz = Mz_new * E1 + ρ * (T(1) - E1)

--- a/KomaMRICore/src/simulation/SimMethods/BlochMagnus/gpu/MagnusMidKernel.jl
+++ b/KomaMRICore/src/simulation/SimMethods/BlochMagnus/gpu/MagnusMidKernel.jl
@@ -14,6 +14,8 @@
     i_g = @index(Group, Linear)
     i = (i_g - 1u32) * UInt32(N) + i_l
 
+    B_to_ω = T(-2π * γ)
+    inv_γ = inv(T(γ))
     sig_group_r = @localmem T HAS_ADC ? (USE_WARP_REDUCTION ? 32 : N) : 1
     sig_group_i = @localmem T HAS_ADC ? (USE_WARP_REDUCTION ? 32 : N) : 1
 
@@ -25,6 +27,8 @@
     ΔBz = zero(T)
     T1 = T(1)
     T2 = T(1)
+    neg_inv_T1 = -one(T)
+    neg_inv_T2 = -one(T)
     x = zero(T)
     y = zero(T)
     z = zero(T)
@@ -36,6 +40,8 @@
         ρ = p_ρ[i]
         T1 = p_T1[i]
         T2 = p_T2[i]
+        neg_inv_T1 = -inv(T1)
+        neg_inv_T2 = -inv(T2)
 
         ψ_start = s_ψ[1]
         if !iszero(ψ_start)
@@ -55,16 +61,16 @@
         if active
             xm, ym, zm = MOTION ? get_spin_coordinates(p_x, p_y, p_z, i, s_mid) : (x, y, z)
             Bx_m, By_m = reim(s_B1[s_mid])
-            Bz_m = xm * s_Gx[s_mid] + ym * s_Gy[s_mid] + zm * s_Gz[s_mid] + ΔBz - s_Δf[s_mid] / T(γ)
+            Bz_m = xm * s_Gx[s_mid] + ym * s_Gy[s_mid] + zm * s_Gz[s_mid] + ΔBz - s_Δf[s_mid] * inv_γ
 
             Δt = s_Δt[s_idx] + s_Δt[s_mid]
-            θx, θy, θz = rotation_vector(Bx_m, By_m, Bz_m, Δt, sim_method)
+            θx, θy, θz = rotation_vector(Bx_m, By_m, Bz_m, Δt, B_to_ω, sim_method)
             M_norm = mag_norm(T, Mxy_r, Mxy_i, Mz)
             Mxy_new_r, Mxy_new_i, Mz_new = rotate_magnetization(θx, θy, θz, Mxy_r, Mxy_i, Mz, T)
             Mxy_new_r, Mxy_new_i, Mz_new = restore_mag_norm(M_norm, Mxy_new_r, Mxy_new_i, Mz_new) # For reduced float precision only.
 
-            E1 = exp(-Δt / T1)
-            E2 = exp(-Δt / T2)
+            E1 = exp(Δt * neg_inv_T1)
+            E2 = exp(Δt * neg_inv_T2)
             Mxy_r = Mxy_new_r * E2
             Mxy_i = Mxy_new_i * E2
             Mz = Mz_new * E1 + ρ * (T(1) - E1)

--- a/KomaMRICore/src/simulation/SimMethods/BlochMagnus/rotation_vectors/MagnusConst1.jl
+++ b/KomaMRICore/src/simulation/SimMethods/BlochMagnus/rotation_vectors/MagnusConst1.jl
@@ -10,12 +10,20 @@ function rotation_vector!(θxy, θz, ωxy_0, ωz_0, ωxy_1, ωz_1, Δt, sim_meth
 end
 
 # -- GPU scalar rotation vector ----------------------------------------------
-@inline function rotation_vector(Bx_0, By_0, Bz_0, Δt, sim_method::SM) where {SM<:Union{Bloch,BlochMagnusConst1}}
-    B_to_ω = typeof(Δt)(-2π * γ)
+@inline function rotation_vector(Bx_0, By_0, Bz_0, Δt, B_to_ω, sim_method::SM) where {SM<:Union{Bloch,BlochMagnusConst1}}
     θx = Bx_0 * B_to_ω * Δt
     θy = By_0 * B_to_ω * Δt
     θz = Bz_0 * B_to_ω * Δt
     return θx, θy, θz
+end
+
+@inline function rotation_vector(Bx_0, By_0, Bz_0, Δt, sim_method::SM) where {SM<:Union{Bloch,BlochMagnusConst1}}
+    B_to_ω = typeof(Δt)(-2π * γ)
+    return rotation_vector(Bx_0, By_0, Bz_0, Δt, B_to_ω, sim_method)
+end
+
+@inline function rotation_vector(Bx_0, By_0, Bz_0, Bx_1, By_1, Bz_1, Δt, B_to_ω, sim_method::SM) where {SM<:Union{Bloch,BlochMagnusConst1}}
+    return rotation_vector(Bx_0, By_0, Bz_0, Δt, B_to_ω, sim_method)
 end
 
 @inline function rotation_vector(Bx_0, By_0, Bz_0, Bx_1, By_1, Bz_1, Δt, sim_method::SM) where {SM<:Union{Bloch,BlochMagnusConst1}}

--- a/KomaMRICore/src/simulation/SimMethods/BlochMagnus/rotation_vectors/MagnusGL2.jl
+++ b/KomaMRICore/src/simulation/SimMethods/BlochMagnus/rotation_vectors/MagnusGL2.jl
@@ -10,13 +10,30 @@ end
     Bx_minus, By_minus, Bz_minus,
     Bx_plus, By_plus, Bz_plus,
     Δt,
+    B_to_ω,
+    B_to_ω2_sqrt3,
     sim_method::BlochMagnusGL2,
 )
-    T = typeof(Δt)
-    B_to_ω = T(-2π * γ)
     θ1_scale = B_to_ω * Δt / 2
     θx = (Bx_minus + Bx_plus) * θ1_scale
     θy = (By_minus + By_plus) * θ1_scale
     θz = (Bz_minus + Bz_plus) * θ1_scale
     return θx, θy, θz
+end
+
+@inline function rotation_vector(
+    Bx_minus, By_minus, Bz_minus,
+    Bx_plus, By_plus, Bz_plus,
+    Δt,
+    sim_method::BlochMagnusGL2,
+)
+    B_to_ω = typeof(Δt)(-2π * γ)
+    return rotation_vector(
+        Bx_minus, By_minus, Bz_minus,
+        Bx_plus, By_plus, Bz_plus,
+        Δt,
+        B_to_ω,
+        B_to_ω * B_to_ω * sqrt(typeof(Δt)(3)),
+        sim_method,
+    )
 end

--- a/KomaMRICore/src/simulation/SimMethods/BlochMagnus/rotation_vectors/MagnusGL4.jl
+++ b/KomaMRICore/src/simulation/SimMethods/BlochMagnus/rotation_vectors/MagnusGL4.jl
@@ -13,12 +13,12 @@ end
     Bx_minus, By_minus, Bz_minus,
     Bx_plus, By_plus, Bz_plus,
     Δt,
+    B_to_ω,
+    B_to_ω2_sqrt3,
     sim_method::BlochMagnusGL4,
 )
-    T = typeof(Δt)
-    B_to_ω = T(-2π * γ)
     θ1_scale = B_to_ω * Δt / 2
-    θ2_scale = B_to_ω^2 * sqrt(T(3)) * Δt^2 / 12
+    θ2_scale = B_to_ω2_sqrt3 * Δt^2 / 12
     θx = (Bx_minus + Bx_plus) * θ1_scale
     θy = (By_minus + By_plus) * θ1_scale
     θz = (Bz_minus + Bz_plus) * θ1_scale
@@ -26,4 +26,21 @@ end
     θy += θ2_scale * (Bz_plus * Bx_minus - Bx_plus * Bz_minus)
     θz += θ2_scale * (Bx_plus * By_minus - By_plus * Bx_minus)
     return θx, θy, θz
+end
+
+@inline function rotation_vector(
+    Bx_minus, By_minus, Bz_minus,
+    Bx_plus, By_plus, Bz_plus,
+    Δt,
+    sim_method::BlochMagnusGL4,
+)
+    B_to_ω = typeof(Δt)(-2π * γ)
+    return rotation_vector(
+        Bx_minus, By_minus, Bz_minus,
+        Bx_plus, By_plus, Bz_plus,
+        Δt,
+        B_to_ω,
+        B_to_ω * B_to_ω * sqrt(typeof(Δt)(3)),
+        sim_method,
+    )
 end

--- a/KomaMRICore/src/simulation/SimMethods/BlochMagnus/rotation_vectors/MagnusMid2.jl
+++ b/KomaMRICore/src/simulation/SimMethods/BlochMagnus/rotation_vectors/MagnusMid2.jl
@@ -9,12 +9,21 @@ end
 @inline function rotation_vector(
     Bx_m, By_m, Bz_m,
     Δt,
+    B_to_ω,
     sim_method::BlochMagnusMid2,
 )
-    B_to_ω = typeof(Δt)(-2π * γ)
     θ_scale = B_to_ω * Δt
     θx = Bx_m * θ_scale
     θy = By_m * θ_scale
     θz = Bz_m * θ_scale
     return θx, θy, θz
+end
+
+@inline function rotation_vector(
+    Bx_m, By_m, Bz_m,
+    Δt,
+    sim_method::BlochMagnusMid2,
+)
+    B_to_ω = typeof(Δt)(-2π * γ)
+    return rotation_vector(Bx_m, By_m, Bz_m, Δt, B_to_ω, sim_method)
 end


### PR DESCRIPTION
## Summary

This PR hoists repeated scalar work out of the benchmarked GPU Bloch and Bloch-Magnus kernel loops.

The PR was intentionally opened from an initial trigger commit first so the `run-gpu-ci` label could be applied before the performance changes were committed and pushed.

## Changes

- Precompute `-2πγ`, `1/γ`, and relaxation reciprocals outside per-step GPU loops.
- Precompute the GL4 `B_to_ω^2 * sqrt(3)` scale once per kernel invocation.
- Add compatible `rotation_vector` overloads that accept precomputed constants while keeping the previous call signatures working.
- Hoist the precession phase scale in the GPU precession kernel.

## Validation

- `git diff --check`
- `Pkg.test("KomaMRICore"; test_args=["CPU"])`: 431 passed
- KernelAbstractions CPU-backend smoke compile/run for the patched GPU-style excitation kernels
- CUDA microbenchmark on Ultron over the six `run-gpu-ci` paths: 1.0446x aggregate median speedup
- Local Metal microbenchmark was noisy/inconclusive, so CUDA is the cleaner performance signal here