### PR TITLE
Fix desktop UI shutdown and startup

### DIFF
--- a/src/KomaCLI.jl
+++ b/src/KomaCLI.jl
@@ -286,6 +286,7 @@ end
 function run_cli(args)
     opts = parse_cli_args(args, load_cli_preferences!(CLIOptions()))
     load_cli_backend!(opts)
+    # Loading a GPU backend may activate package extensions in a newer world.
     return Base.invokelatest(run_cli, opts)
 end
 
@@ -310,11 +311,17 @@ end
 @setup_workload begin
     @compile_workload begin
         redirect_stderr(devnull) do
+            opts = CLIOptions()
+            sys, seq, obj = cli_inputs(opts)
             w = KomaUI(;
+                sys,
+                seq,
+                obj,
+                sim=opts.sim_params,
+                rec=opts.recon_params,
                 show_window=false,
                 return_window=true,
                 verbose=false,
-                sim=Dict{String,Any}("gpu" => false),
             )
             close(w)
         end

--- a/src/KomaCLI.jl
+++ b/src/KomaCLI.jl
@@ -279,9 +279,7 @@ function print_cli_versions()
 end
 
 function keep_app_open(w)
-    while !isnothing(w.session[]) && isopen(w.session[])
-        sleep(0.2)
-    end
+    wait(w)
     return nothing
 end
 
@@ -312,10 +310,13 @@ end
 @setup_workload begin
     @compile_workload begin
         redirect_stderr(devnull) do
-            sys = setup_scanner()
-            setup_sequence(sys)
-            setup_phantom()
-            setup_raw()
+            w = KomaUI(;
+                show_window=false,
+                return_window=true,
+                verbose=false,
+                sim=Dict{String,Any}("gpu" => false),
+            )
+            close(w)
         end
     end
 end

--- a/src/ui/BonitoUI.jl
+++ b/src/ui/BonitoUI.jl
@@ -20,6 +20,9 @@ function launch_ui(;
         "KomaMRIPlots.jl v$(pkgversion(KomaMRIPlots))",
     ], "\n")
     w = setup_bonito_window(; darkmode, frame, dev_tools, versions)
+    seq_file = Ref("")
+    setup_filepickers!(w; seq_file)
+    show_window && show!(w)
 
     fieldnames_obj = [fieldnames(Phantom)[5:end-3]...]
     widgets_button_obj = [Button(string(field); style=nothing, class="btn btn-dark btn-sm m-1") for field in fieldnames_obj]
@@ -38,7 +41,6 @@ function launch_ui(;
 
     sim_params = merge(Dict{String,Any}(), sim)
     rec_params = merge(Dict{Symbol,Any}(:reco => "direct"), rec)
-    seq_file = Ref("")
 
     if !(haskey(sim_params, "gpu") && sim_params["gpu"] == false)
         KomaMRICore.print_devices()
@@ -129,9 +131,6 @@ function launch_ui(;
     push!(w.listeners, on(raw -> show_signal!(w, raw; darkmode), raw_ui))
     push!(w.listeners, on(img -> show_image!(w, img, :absi; darkmode), img_ui))
 
-    setup_filepickers!(w; seq_file)
-
     @info "KomaMRI loaded successfully 🚀" KomaMRI=string(pkgversion(KomaMRI)) KomaMRIBase=string(pkgversion(KomaMRIBase)) KomaMRICore=string(pkgversion(KomaMRICore)) KomaMRIFiles=string(pkgversion(KomaMRIFiles)) KomaMRIPlots=string(pkgversion(KomaMRIPlots))
-    show_window && show!(w)
     return return_window ? w : nothing
 end

--- a/src/ui/ExportUI.jl
+++ b/src/ui/ExportUI.jl
@@ -1,6 +1,6 @@
 function select_export_folder(w::KomaWindow)
     isnothing(w.display[]) && return tempdir()
-    window = w.display[].window.window
+    window = w.window[]
     folders = Base.run(window.app, """
         electron.dialog.showOpenDialogSync(
             electron.BrowserWindow.fromId($(window.id)),

--- a/src/ui/SimulationUI.jl
+++ b/src/ui/SimulationUI.jl
@@ -5,8 +5,7 @@ function run_simulation!(w, sim_params; initial=false)
         "Precompiling and running simulation functions ..." : "Running simulation ..."
     threads = get(sim_params, "Nthreads", Threads.nthreads())
     simulation_device = Ref("CPU ($threads thread$(threads == 1 ? "" : "s"))")
-    details = get(sim_params, "gpu", true) ? "Selecting GPU backend ..." : simulation_device[]
-    display_loading!(w, message; details)
+    display_loading!(w, message)
     start_simulation_progress!(w)
 
     raw = try

--- a/src/ui/WindowUI.jl
+++ b/src/ui/WindowUI.jl
@@ -1,6 +1,7 @@
 struct KomaWindow
     app::App
     display::Base.RefValue{Any}
+    window::Base.RefValue{Union{Nothing,Electron.Window}}
     session::Base.RefValue{Union{Nothing,Session}}
     content::Observable{Any}
     state::Observable{String}
@@ -53,10 +54,27 @@ function handle(callback::Function, w::KomaWindow, event::String)
 end
 
 function show!(w::KomaWindow)
+    windows = Set(Iterators.flatten(Electron.windows.(Electron.applications())))
     display = Bonito.use_electron_display(; options=w.window_options, devtools=w.dev_tools)
     w.display[] = display
+    w.window[] = only(
+        setdiff(Iterators.flatten(Electron.windows.(Electron.applications())), windows)
+    )
     Base.display(display, w.app)
     return w
+end
+
+function Base.isopen(w::KomaWindow)
+    window = w.window[]
+    return !isnothing(window) && isopen(window)
+end
+
+function Base.wait(w::KomaWindow)
+    window = w.window[]
+    isnothing(window) && return nothing
+    for _ in Electron.msgchannel(window)
+    end
+    return nothing
 end
 
 function Base.close(w::KomaWindow)
@@ -72,6 +90,7 @@ function Base.close(w::KomaWindow)
         close(display)
         w.display[] = nothing
     end
+    w.window[] = nothing
     return nothing
 end
 
@@ -250,6 +269,7 @@ function setup_bonito_window(; darkmode=true, frame=true, dev_tools=false, versi
     return KomaWindow(
         app,
         display_ref,
+        Ref{Union{Nothing,Electron.Window}}(nothing),
         session_ref,
         content,
         state,

--- a/src/ui/WindowUI.jl
+++ b/src/ui/WindowUI.jl
@@ -54,12 +54,9 @@ function handle(callback::Function, w::KomaWindow, event::String)
 end
 
 function show!(w::KomaWindow)
-    windows = Set(Iterators.flatten(Electron.windows.(Electron.applications())))
     display = Bonito.use_electron_display(; options=w.window_options, devtools=w.dev_tools)
     w.display[] = display
-    w.window[] = only(
-        setdiff(Iterators.flatten(Electron.windows.(Electron.applications())), windows)
-    )
+    w.window[] = display.window.window
     Base.display(display, w.app)
     return w
 end
@@ -72,8 +69,8 @@ end
 function Base.wait(w::KomaWindow)
     window = w.window[]
     isnothing(window) && return nothing
-    for _ in Electron.msgchannel(window)
-    end
+    # Electron closes this channel when its window closes.
+    foreach(_ -> nothing, Electron.msgchannel(window))
     return nothing
 end
 
@@ -133,7 +130,7 @@ function home_page(image)
                         style="color:#2a7fb8;",
                     ),
                     ", et al.";
-                    style="padding-bottom:10px;",
+                    class="mb-1",
                 ),
                 DOM.p(
                     "Cite us ",
@@ -150,7 +147,7 @@ function home_page(image)
                     DOM.img(
                         ;
                         src="https://contrib.rocks/image?repo=cncastillo/KomaMRI.jl",
-                        style="height:60px;",
+                        style="height:48px;",
                     );
                     href="https://github.com/cncastillo/KomaMRI.jl/graphs/contributors",
                 );

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -405,6 +405,13 @@ end
                     @test !isempty(raw_ui[].profiles)
                     @test timedwait(() -> w.state[] == "sig", 30) == :ok
                 end
+
+                @testset "Close UI" begin
+                    waiter = @async KomaMRI.keep_app_open(w)
+                    close(w.window[])
+                    @test timedwait(() -> istaskdone(waiter), 30) == :ok
+                    @test !isopen(w)
+                end
             finally
                 close(w)
             end


### PR DESCRIPTION
## Summary

- wait for the native Electron window to close instead of polling the Bonito session
- retain the Electron window on `KomaWindow` for lifecycle handling and native export-folder dialogs
- precompile the complete headless UI construction path used by the CLI

## Validation

- `Pkg.test()`: 720/720 passed
- native close regression: waiter completed and `isopen(w)` became false
- no Electron `EPIPE` on close
- UI reopened and visually reviewed after the home-page changes
- `git diff --check`
- CPU only; GPU tests were not run
