### PR TITLE
Fix Julia Dependabot workspace updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,14 +15,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    exclude-paths:
-      - "test/**"
-      - "docs/**"
-      - "benchmarks/**"
-      - "KomaMRIBase/test/**"
-      - "KomaMRICore/test/**"
-      - "KomaMRIFiles/test/**"
-      - "KomaMRIPlots/test/**"
     labels:
       - "dependencies"
       - "julia"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,15 +11,22 @@ updates:
       - "github-actions"
 
   - package-ecosystem: "julia"
-    directories:
-      - "/"
-      - "/KomaMRIBase"
-      - "/KomaMRICore"
-      - "/KomaMRIFiles"
-      - "/KomaMRIPlots"
+    directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 100
+    open-pull-requests-limit: 5
+    exclude-paths:
+      - "test/**"
+      - "docs/**"
+      - "benchmarks/**"
+      - "KomaMRIBase/test/**"
+      - "KomaMRICore/test/**"
+      - "KomaMRIFiles/test/**"
+      - "KomaMRIPlots/test/**"
+    groups:
+      julia-dependencies:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "julia"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 100
     labels:
       - "dependencies"
       - "julia"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,10 +23,6 @@ updates:
       - "KomaMRICore/test/**"
       - "KomaMRIFiles/test/**"
       - "KomaMRIPlots/test/**"
-    groups:
-      julia-dependencies:
-        patterns:
-          - "*"
     labels:
       - "dependencies"
       - "julia"


### PR DESCRIPTION
## Summary

Scan the Julia workspace once from `/` instead of five overlapping directories.

The upstream [Dependabot Julia workspace fix](https://github.com/dependabot/dependabot-core/commit/6461720c7ee8651de691cd7e5ac66963502eae2c) now ignores internal workspace packages and compat-less test, docs, and benchmark dependencies.

## Validation

- fixed Dependabot updater against `master`: 0 updates
- Dependabot configuration check passes