### PR TITLE
Enable Reactant AD through sequence discretization

### DIFF
--- a/KomaMRIBase/Project.toml
+++ b/KomaMRIBase/Project.toml
@@ -19,9 +19,11 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [weakdeps]
+Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
+KomaMRIBaseReactantExt = "Reactant"
 KomaMRIBaseUnitfulExt = "Unitful"
 
 [compat]
@@ -32,6 +34,7 @@ Interpolations = "0.13, 0.14, 0.15, 0.16"
 MAT = "0.10, 0.11, 0.12"
 MRIBase = "0.4"
 Parameters = "0.12, 0.13"
+Reactant = "0.2"
 Reexport = "1"
 Unitful = "1"
 julia = "1.9"

--- a/KomaMRIBase/ext/KomaMRIBaseReactantExt.jl
+++ b/KomaMRIBase/ext/KomaMRIBaseReactantExt.jl
@@ -1,0 +1,208 @@
+module KomaMRIBaseReactantExt
+
+using KomaMRIBase
+using Reactant
+
+import KomaMRIBase: DiscreteSequence, RF, Sequence, ampls, freq_times, freqs,
+    linear_interpolate_samples, sample_sequence, times
+
+const ReactantRVector = Union{
+    Reactant.AnyTracedRVector,
+    Reactant.AbstractConcreteArray{<:Number,1},
+}
+
+const ReactantRF = RF{<:ReactantRVector,<:Number,<:Number}
+
+const ReactantSequence = Sequence{
+    GT,
+    RT,
+    AT,
+    DT,
+    XT,
+    DF,
+} where {
+    GT,
+    RT<:AbstractMatrix{<:ReactantRF},
+    AT,
+    DT,
+    XT,
+    DF,
+}
+
+const ReactantDiscreteSequence = DiscreteSequence{
+    <:AbstractVector,
+    <:AbstractVector,
+    <:AbstractVector,
+    <:ReactantRVector,
+}
+
+function _prepend(value, values)
+    out = similar(values, length(values) + 1)
+    Reactant.allowscalar() do
+        out[1] = value
+        for i in eachindex(values)
+            out[i + 1] = values[i]
+        end
+    end
+    return out
+end
+
+function _prepend_first(values)
+    out = similar(values, length(values) + 1)
+    Reactant.allowscalar() do
+        for i in eachindex(values)
+            out[i + 1] = values[i]
+        end
+        out[1] = out[2]
+    end
+    return out
+end
+
+function _copy_like(template, values)
+    out = similar(template, eltype(values), size(values))
+    Reactant.allowscalar() do
+        for i in eachindex(values)
+            out[i] = values[i]
+        end
+    end
+    return out
+end
+
+function _with_adc_start_padding(values::ReactantDiscreteSequence)
+    (isempty(values.ADC) || !first(values.ADC)) && return values
+    return DiscreteSequence(
+        _prepend_first(values.Gx),
+        _prepend_first(values.Gy),
+        _prepend_first(values.Gz),
+        _prepend_first(values.B1),
+        _prepend_first(values.Δf),
+        _prepend_first(values.ψ),
+        _prepend(false, values.ADC),
+        _prepend(false, values.excitation_bool),
+        _prepend_first(values.t),
+        _prepend(zero(eltype(values.Δt)), values.Δt),
+    )
+end
+
+function sample_sequence(
+    seq::ReactantSequence;
+    motion=KomaMRIBase.NoMotion(),
+    sampling_rule=KomaMRIBase.MaxStepSizeRule(1e-3, 5e-5),
+    freq_in_phase=false,
+)
+    length(seq) == 1 || throw(ArgumentError(
+        "Reactant RF sequence discretization currently supports one-block sequences only.",
+    ))
+    T0 = KomaMRIBase.get_block_start_times(seq)
+    global_event_times = KomaMRIBase.merge_sampling_times(
+        KomaMRIBase.sequence_boundary_sampling_times(seq),
+        KomaMRIBase.motion_sampling_times(seq, motion),
+    )
+    values = KomaMRIBase.sample_sequence_block(
+        seq,
+        1;
+        sampling_rule,
+        motion_times=KomaMRIBase.block_global_event_times(T0, 1, global_event_times),
+        freq_in_phase,
+    )
+    return _with_adc_start_padding(values)
+end
+
+function _shape_rf_samples(rf::ReactantRF)
+    # Traced amplitudes cannot control output shape, so keep the RF sampling grid fixed even
+    # when every amplitude evaluates to zero.
+    A = cis(rf.ϕ) .* rf.A
+    length(A) == 1 && (A = A[[1, 1]])
+    out = similar(A, eltype(A), length(A) + 2)
+    Reactant.allowscalar() do
+        out[1] = zero(eltype(A))
+        for i in eachindex(A)
+            out[i + 1] = A[i]
+        end
+        out[end] = zero(eltype(A))
+    end
+    return out
+end
+
+ampls(rf::ReactantRF; freq_in_phase=false) = begin
+    freq_in_phase && !iszero(rf.Δf) &&
+        throw(ArgumentError("Reactant RF discretization does not yet support frequency offsets folded into phase."))
+    _shape_rf_samples(rf)
+end
+
+function times(rf::ReactantRF)
+    t = length(rf.A) == 1 ?
+        [rf.delay, rf.delay, KomaMRIBase.dur(rf), KomaMRIBase.dur(rf)] :
+        collect(range(rf.delay, KomaMRIBase.dur(rf); length=length(rf.A)))
+    return length(rf.A) == 1 ? t : [first(t); t; last(t)]
+end
+
+freq_times(rf::ReactantRF) =
+    [rf.delay, rf.delay, KomaMRIBase.dur(rf), KomaMRIBase.dur(rf)]
+
+function freqs(rf::ReactantRF)
+    out = fill(rf.Δf, length(freq_times(rf)))
+    out[begin] = zero(rf.Δf)
+    out[end] = zero(rf.Δf)
+    return out
+end
+
+function linear_interpolate_samples(
+    samples::NamedTuple{(:t,:A),Tuple{TT,AT}},
+    t;
+    default=zero(eltype(samples.A)),
+    interpolate=true,
+) where {TT,AT<:ReactantRVector}
+    defaults = fill(default, length(t))
+    (isempty(samples.t) || isempty(samples.A)) &&
+        return _copy_like(samples.A, defaults)
+
+    weight_type = typeof(real(default))
+    lo_indices = fill(firstindex(samples.A), length(t))
+    hi_indices = copy(lo_indices)
+    lo_weights = zeros(weight_type, length(t))
+    hi_weights = zeros(weight_type, length(t))
+    last_sample = min(lastindex(samples.t), lastindex(samples.A))
+    sample = firstindex(samples.t)
+    i = firstindex(t)
+    while i <= lastindex(t)
+        ti = t[i]
+        j = i
+        while j < lastindex(t) && t[j + 1] == ti
+            j += 1
+        end
+        while sample <= last_sample && samples.t[sample] < ti
+            sample += 1
+        end
+        if sample <= last_sample && samples.t[sample] == ti
+            sample_end = sample
+            while sample_end < last_sample && samples.t[sample_end + 1] == ti
+                sample_end += 1
+            end
+            for k in i:j
+                l = interpolate ? min(sample + k - i, sample_end) : sample_end - (j - k)
+                if l >= sample
+                    lo_indices[k] = l
+                    hi_indices[k] = l
+                    lo_weights[k] = one(weight_type)
+                    defaults[k] = zero(default)
+                end
+            end
+            sample = sample_end + 1
+        elseif interpolate && ti >= first(samples.t) && sample <= last_sample
+            lo_time, hi_time = samples.t[sample - 1], samples.t[sample]
+            weight = weight_type((ti - lo_time) / (hi_time - lo_time))
+            lo_indices[i:j] .= sample - 1
+            hi_indices[i:j] .= sample
+            lo_weights[i:j] .= one(weight_type) - weight
+            hi_weights[i:j] .= weight
+            defaults[i:j] .= zero(default)
+        end
+        i = j + 1
+    end
+    return samples.A[lo_indices] .* _copy_like(samples.A, lo_weights) .+
+           samples.A[hi_indices] .* _copy_like(samples.A, hi_weights) .+
+           _copy_like(samples.A, defaults)
+end
+
+end

--- a/KomaMRIBase/ext/KomaMRIBaseReactantExt.jl
+++ b/KomaMRIBase/ext/KomaMRIBaseReactantExt.jl
@@ -3,28 +3,10 @@ module KomaMRIBaseReactantExt
 using KomaMRIBase
 using Reactant
 
-import KomaMRIBase: RF, _scalar_getindex, _scalar_setindex!, is_on
-
-const ReactantRVector = Union{
-    Reactant.AnyTracedRVector,
-    Reactant.AbstractConcreteArray{<:Number,1},
-}
+import KomaMRIBase: RF, is_on
 
 # A traced RF waveform has a statically known shape, but its values cannot be
 # inspected on the host to determine whether the event is active.
-is_on(rf::RF{<:ReactantRVector}) = !isempty(rf.A)
-
-function _scalar_getindex(x::ReactantRVector, i)
-    return Reactant.allowscalar() do
-        x[i]
-    end
-end
-
-function _scalar_setindex!(x::ReactantRVector, value, i)
-    Reactant.allowscalar() do
-        x[i] = value
-    end
-    return x
-end
+is_on(rf::RF{<:Reactant.AnyTracedRVector}) = !isempty(rf.A)
 
 end

--- a/KomaMRIBase/ext/KomaMRIBaseReactantExt.jl
+++ b/KomaMRIBase/ext/KomaMRIBaseReactantExt.jl
@@ -3,206 +3,28 @@ module KomaMRIBaseReactantExt
 using KomaMRIBase
 using Reactant
 
-import KomaMRIBase: DiscreteSequence, RF, Sequence, ampls, freq_times, freqs,
-    linear_interpolate_samples, sample_sequence, times
+import KomaMRIBase: RF, _scalar_getindex, _scalar_setindex!, is_on
 
 const ReactantRVector = Union{
     Reactant.AnyTracedRVector,
     Reactant.AbstractConcreteArray{<:Number,1},
 }
 
-const ReactantRF = RF{<:ReactantRVector,<:Number,<:Number}
+# A traced RF waveform has a statically known shape, but its values cannot be
+# inspected on the host to determine whether the event is active.
+is_on(rf::RF{<:ReactantRVector}) = !isempty(rf.A)
 
-const ReactantSequence = Sequence{
-    GT,
-    RT,
-    AT,
-    DT,
-    XT,
-    DF,
-} where {
-    GT,
-    RT<:AbstractMatrix{<:ReactantRF},
-    AT,
-    DT,
-    XT,
-    DF,
-}
+function _scalar_getindex(x::ReactantRVector, i)
+    return Reactant.allowscalar() do
+        x[i]
+    end
+end
 
-const ReactantDiscreteSequence = DiscreteSequence{
-    <:AbstractVector,
-    <:AbstractVector,
-    <:AbstractVector,
-    <:ReactantRVector,
-}
-
-function _prepend(value, values)
-    out = similar(values, length(values) + 1)
+function _scalar_setindex!(x::ReactantRVector, value, i)
     Reactant.allowscalar() do
-        out[1] = value
-        for i in eachindex(values)
-            out[i + 1] = values[i]
-        end
+        x[i] = value
     end
-    return out
-end
-
-function _prepend_first(values)
-    out = similar(values, length(values) + 1)
-    Reactant.allowscalar() do
-        for i in eachindex(values)
-            out[i + 1] = values[i]
-        end
-        out[1] = out[2]
-    end
-    return out
-end
-
-function _copy_like(template, values)
-    out = similar(template, eltype(values), size(values))
-    Reactant.allowscalar() do
-        for i in eachindex(values)
-            out[i] = values[i]
-        end
-    end
-    return out
-end
-
-function _with_adc_start_padding(values::ReactantDiscreteSequence)
-    (isempty(values.ADC) || !first(values.ADC)) && return values
-    return DiscreteSequence(
-        _prepend_first(values.Gx),
-        _prepend_first(values.Gy),
-        _prepend_first(values.Gz),
-        _prepend_first(values.B1),
-        _prepend_first(values.Δf),
-        _prepend_first(values.ψ),
-        _prepend(false, values.ADC),
-        _prepend(false, values.excitation_bool),
-        _prepend_first(values.t),
-        _prepend(zero(eltype(values.Δt)), values.Δt),
-    )
-end
-
-function sample_sequence(
-    seq::ReactantSequence;
-    motion=KomaMRIBase.NoMotion(),
-    sampling_rule=KomaMRIBase.MaxStepSizeRule(1e-3, 5e-5),
-    freq_in_phase=false,
-)
-    length(seq) == 1 || throw(ArgumentError(
-        "Reactant RF sequence discretization currently supports one-block sequences only.",
-    ))
-    T0 = KomaMRIBase.get_block_start_times(seq)
-    global_event_times = KomaMRIBase.merge_sampling_times(
-        KomaMRIBase.sequence_boundary_sampling_times(seq),
-        KomaMRIBase.motion_sampling_times(seq, motion),
-    )
-    values = KomaMRIBase.sample_sequence_block(
-        seq,
-        1;
-        sampling_rule,
-        motion_times=KomaMRIBase.block_global_event_times(T0, 1, global_event_times),
-        freq_in_phase,
-    )
-    return _with_adc_start_padding(values)
-end
-
-function _shape_rf_samples(rf::ReactantRF)
-    # Traced amplitudes cannot control output shape, so keep the RF sampling grid fixed even
-    # when every amplitude evaluates to zero.
-    A = cis(rf.ϕ) .* rf.A
-    length(A) == 1 && (A = A[[1, 1]])
-    out = similar(A, eltype(A), length(A) + 2)
-    Reactant.allowscalar() do
-        out[1] = zero(eltype(A))
-        for i in eachindex(A)
-            out[i + 1] = A[i]
-        end
-        out[end] = zero(eltype(A))
-    end
-    return out
-end
-
-ampls(rf::ReactantRF; freq_in_phase=false) = begin
-    freq_in_phase && !iszero(rf.Δf) &&
-        throw(ArgumentError("Reactant RF discretization does not yet support frequency offsets folded into phase."))
-    _shape_rf_samples(rf)
-end
-
-function times(rf::ReactantRF)
-    t = length(rf.A) == 1 ?
-        [rf.delay, rf.delay, KomaMRIBase.dur(rf), KomaMRIBase.dur(rf)] :
-        collect(range(rf.delay, KomaMRIBase.dur(rf); length=length(rf.A)))
-    return length(rf.A) == 1 ? t : [first(t); t; last(t)]
-end
-
-freq_times(rf::ReactantRF) =
-    [rf.delay, rf.delay, KomaMRIBase.dur(rf), KomaMRIBase.dur(rf)]
-
-function freqs(rf::ReactantRF)
-    out = fill(rf.Δf, length(freq_times(rf)))
-    out[begin] = zero(rf.Δf)
-    out[end] = zero(rf.Δf)
-    return out
-end
-
-function linear_interpolate_samples(
-    samples::NamedTuple{(:t,:A),Tuple{TT,AT}},
-    t;
-    default=zero(eltype(samples.A)),
-    interpolate=true,
-) where {TT,AT<:ReactantRVector}
-    defaults = fill(default, length(t))
-    (isempty(samples.t) || isempty(samples.A)) &&
-        return _copy_like(samples.A, defaults)
-
-    weight_type = typeof(real(default))
-    lo_indices = fill(firstindex(samples.A), length(t))
-    hi_indices = copy(lo_indices)
-    lo_weights = zeros(weight_type, length(t))
-    hi_weights = zeros(weight_type, length(t))
-    last_sample = min(lastindex(samples.t), lastindex(samples.A))
-    sample = firstindex(samples.t)
-    i = firstindex(t)
-    while i <= lastindex(t)
-        ti = t[i]
-        j = i
-        while j < lastindex(t) && t[j + 1] == ti
-            j += 1
-        end
-        while sample <= last_sample && samples.t[sample] < ti
-            sample += 1
-        end
-        if sample <= last_sample && samples.t[sample] == ti
-            sample_end = sample
-            while sample_end < last_sample && samples.t[sample_end + 1] == ti
-                sample_end += 1
-            end
-            for k in i:j
-                l = interpolate ? min(sample + k - i, sample_end) : sample_end - (j - k)
-                if l >= sample
-                    lo_indices[k] = l
-                    hi_indices[k] = l
-                    lo_weights[k] = one(weight_type)
-                    defaults[k] = zero(default)
-                end
-            end
-            sample = sample_end + 1
-        elseif interpolate && ti >= first(samples.t) && sample <= last_sample
-            lo_time, hi_time = samples.t[sample - 1], samples.t[sample]
-            weight = weight_type((ti - lo_time) / (hi_time - lo_time))
-            lo_indices[i:j] .= sample - 1
-            hi_indices[i:j] .= sample
-            lo_weights[i:j] .= one(weight_type) - weight
-            hi_weights[i:j] .= weight
-            defaults[i:j] .= zero(default)
-        end
-        i = j + 1
-    end
-    return samples.A[lo_indices] .* _copy_like(samples.A, lo_weights) .+
-           samples.A[hi_indices] .* _copy_like(samples.A, hi_weights) .+
-           _copy_like(samples.A, defaults)
+    return x
 end
 
 end

--- a/KomaMRIBase/src/datatypes/sequence/RF.jl
+++ b/KomaMRIBase/src/datatypes/sequence/RF.jl
@@ -259,6 +259,8 @@ function rf_center(rf::RF)
     weights = abs.(ampls(rf))
     isempty(weights) && return 0.0
     total = sum(weights)
-    iszero(total) && return 0.0
-    return sum(weights .* (times(rf) .- rf.delay)) / total
+    active = !iszero(total)
+    denominator = ifelse(active, total, one(total))
+    center = sum(weights .* (times(rf) .- rf.delay)) / denominator
+    return ifelse(active, center, zero(center))
 end

--- a/KomaMRIBase/src/datatypes/sequence/SequenceEventWaveforms.jl
+++ b/KomaMRIBase/src/datatypes/sequence/SequenceEventWaveforms.jl
@@ -17,6 +17,18 @@ is_GR_on(x::Grad) = is_on(x)
 is_RF_on(x::RF) = is_on(x)
 is_ADC_on(x::ADC) = is_on(x)
 
+@inline _scalar_getindex(x, i) = x[i]
+@inline _scalar_setindex!(x, value, i) = setindex!(x, value, i)
+
+function _zero_pad_samples(A)
+    out = similar(A, length(A) + 2)
+    fill!(out, zero(eltype(A)))
+    for i in eachindex(A)
+        _scalar_setindex!(out, _scalar_getindex(A, i), i + 1)
+    end
+    return out
+end
+
 # -- 1.2. Event amplitudes and RF frequency offsets --------------------------
 """
     A = ampls(g::Grad)
@@ -47,10 +59,10 @@ function ampls(rf::BlockPulseRF; freq_in_phase=false)
 end
 
 function ampls(rf::RF; freq_in_phase=false)
-    A = collect(cis(rf.ϕ) .* rf.A)
+    A = cis(rf.ϕ) .* rf.A
     is_on(rf) || return similar(A, 0)
-    length(A) == 1 && (A = [only(A), only(A)])
-    A = [zero(eltype(A)); A; zero(eltype(A))]
+    length(A) == 1 && (A = A[[1, 1]])
+    A = _zero_pad_samples(A)
     if freq_in_phase
         t  = times(rf)
         Δf = (t=times(rf, :Δf)[2:(end - 1)], A=freqs(rf)[2:(end - 1)])

--- a/KomaMRIBase/src/datatypes/sequence/SequenceEventWaveforms.jl
+++ b/KomaMRIBase/src/datatypes/sequence/SequenceEventWaveforms.jl
@@ -17,18 +17,6 @@ is_GR_on(x::Grad) = is_on(x)
 is_RF_on(x::RF) = is_on(x)
 is_ADC_on(x::ADC) = is_on(x)
 
-@inline _scalar_getindex(x, i) = x[i]
-@inline _scalar_setindex!(x, value, i) = setindex!(x, value, i)
-
-function _zero_pad_samples(A)
-    out = similar(A, length(A) + 2)
-    fill!(out, zero(eltype(A)))
-    for i in eachindex(A)
-        _scalar_setindex!(out, _scalar_getindex(A, i), i + 1)
-    end
-    return out
-end
-
 # -- 1.2. Event amplitudes and RF frequency offsets --------------------------
 """
     A = ampls(g::Grad)
@@ -62,7 +50,10 @@ function ampls(rf::RF; freq_in_phase=false)
     A = cis(rf.ϕ) .* rf.A
     is_on(rf) || return similar(A, 0)
     length(A) == 1 && (A = A[[1, 1]])
-    A = _zero_pad_samples(A)
+    out = similar(A, length(A) + 2)
+    fill!(out, zero(eltype(A)))
+    out[2:(end - 1)] .= A
+    A = out
     if freq_in_phase
         t  = times(rf)
         Δf = (t=times(rf, :Δf)[2:(end - 1)], A=freqs(rf)[2:(end - 1)])

--- a/KomaMRIBase/src/discretization/SequenceSampling.jl
+++ b/KomaMRIBase/src/discretization/SequenceSampling.jl
@@ -55,7 +55,7 @@ end
 
 # -- 6.3. Sample the full sequence ------------------------------------------
 function sample_sequence(seq; motion=NoMotion(), sampling_rule=MaxStepSizeRule(1e-3, 5e-5), freq_in_phase=false)
-    isempty(seq) && return DiscreteSequence()
+    length(seq) == 0 && return DiscreteSequence()
     T0 = get_block_start_times(seq)
     global_event_times = merge_sampling_times(sequence_boundary_sampling_times(seq), motion_sampling_times(seq, motion))
     values = sample_sequence_block(seq, 1; sampling_rule, motion_times=block_global_event_times(T0, 1, global_event_times), freq_in_phase)

--- a/KomaMRIBase/src/discretization/SequenceSampling.jl
+++ b/KomaMRIBase/src/discretization/SequenceSampling.jl
@@ -29,40 +29,15 @@ function append_adc_start_padding!(out, values, first_t)
     return out
 end
 
-function _prepend_sample(value, values)
-    out = similar(values, length(values) + 1)
-    _scalar_setindex!(out, value, firstindex(out))
-    for i in eachindex(values)
-        _scalar_setindex!(out, _scalar_getindex(values, i), i + 1)
-    end
-    return out
-end
-
-function _with_adc_start_padding(values)
-    (isempty(values.ADC) || !first(values.ADC)) && return values
-    return DiscreteSequence(
-        _prepend_sample(_scalar_getindex(values.Gx, firstindex(values.Gx)), values.Gx),
-        _prepend_sample(_scalar_getindex(values.Gy, firstindex(values.Gy)), values.Gy),
-        _prepend_sample(_scalar_getindex(values.Gz, firstindex(values.Gz)), values.Gz),
-        _prepend_sample(_scalar_getindex(values.B1, firstindex(values.B1)), values.B1),
-        _prepend_sample(_scalar_getindex(values.Δf, firstindex(values.Δf)), values.Δf),
-        _prepend_sample(_scalar_getindex(values.ψ, firstindex(values.ψ)), values.ψ),
-        _prepend_sample(false, values.ADC),
-        _prepend_sample(false, values.excitation_bool),
-        _prepend_sample(_scalar_getindex(values.t, firstindex(values.t)), values.t),
-        _prepend_sample(zero(eltype(values.Δt)), values.Δt),
-    )
-end
-
-function same_boundary_sample(out, values)
-    return all(last(dst) == first(src) for (dst, src) in zip(table_columns(out), table_columns(values)))
-end
-
 function append_sampled_block!(out, values, t0)
     isempty(values.t) && return out
     first_t = t0 + first(values.t)
     first_row = firstindex(values.t)
-    isempty(out.t) ? append_adc_start_padding!(out, values, first_t) : if first_t == last(out.t) && same_boundary_sample(out, values)
+    if isempty(out.t)
+        append_adc_start_padding!(out, values, first_t)
+    elseif all(dst -> dst isa Vector, table_columns(out)) &&
+           first_t == last(out.t) &&
+           all(last(dst) == first(src) for (dst, src) in zip(table_columns(out), table_columns(values)))
         first_row += 1
     else
         push!(out.Δt, first_t - last(out.t))
@@ -72,7 +47,7 @@ function append_sampled_block!(out, values, t0)
     for t in view(values.t, rows)
         push!(out.t, t0 + t)
     end
-    foreach((dst, src) -> append!(dst, view(src, rows)), table_columns(out), table_columns(values))
+    foreach((dst, src) -> append!(dst, dst isa Vector ? view(src, rows) : src[rows]), table_columns(out), table_columns(values))
     append!(out.Δt, values.Δt)
     append!(out.excitation_bool, values.excitation_bool)
     return out
@@ -80,16 +55,16 @@ end
 
 # -- 6.3. Sample the full sequence ------------------------------------------
 function sample_sequence(seq; motion=NoMotion(), sampling_rule=MaxStepSizeRule(1e-3, 5e-5), freq_in_phase=false)
+    isempty(seq) && return DiscreteSequence()
     T0 = get_block_start_times(seq)
     global_event_times = merge_sampling_times(sequence_boundary_sampling_times(seq), motion_sampling_times(seq, motion))
-    if length(seq) == 1
-        values = sample_sequence_block(seq, 1; sampling_rule, motion_times=block_global_event_times(T0, 1, global_event_times), freq_in_phase)
-        return _with_adc_start_padding(values)
-    end
-    out = DiscreteSequence()
+    values = sample_sequence_block(seq, 1; sampling_rule, motion_times=block_global_event_times(T0, 1, global_event_times), freq_in_phase)
+    columns = (table_columns(values)..., values.excitation_bool, values.t, values.Δt)
+    out = DiscreteSequence(map(x -> similar(x, 0), columns)...)
     sizehint = max(8length(seq), 5sum(seq.ADC.N))
-    foreach(x -> Base.sizehint!(x, sizehint), (out.t, table_columns(out)..., out.excitation_bool, out.Δt))
-    for block in 1:length(seq)
+    foreach(x -> x isa Vector && Base.sizehint!(x, sizehint), (out.t, table_columns(out)..., out.excitation_bool, out.Δt))
+    append_sampled_block!(out, values, T0[1])
+    for block in 2:length(seq)
         values = sample_sequence_block(seq, block; sampling_rule, motion_times=block_global_event_times(T0, block, global_event_times), freq_in_phase)
         append_sampled_block!(out, values, T0[block])
     end

--- a/KomaMRIBase/src/discretization/SequenceSampling.jl
+++ b/KomaMRIBase/src/discretization/SequenceSampling.jl
@@ -29,6 +29,31 @@ function append_adc_start_padding!(out, values, first_t)
     return out
 end
 
+function _prepend_sample(value, values)
+    out = similar(values, length(values) + 1)
+    _scalar_setindex!(out, value, firstindex(out))
+    for i in eachindex(values)
+        _scalar_setindex!(out, _scalar_getindex(values, i), i + 1)
+    end
+    return out
+end
+
+function _with_adc_start_padding(values)
+    (isempty(values.ADC) || !first(values.ADC)) && return values
+    return DiscreteSequence(
+        _prepend_sample(_scalar_getindex(values.Gx, firstindex(values.Gx)), values.Gx),
+        _prepend_sample(_scalar_getindex(values.Gy, firstindex(values.Gy)), values.Gy),
+        _prepend_sample(_scalar_getindex(values.Gz, firstindex(values.Gz)), values.Gz),
+        _prepend_sample(_scalar_getindex(values.B1, firstindex(values.B1)), values.B1),
+        _prepend_sample(_scalar_getindex(values.Δf, firstindex(values.Δf)), values.Δf),
+        _prepend_sample(_scalar_getindex(values.ψ, firstindex(values.ψ)), values.ψ),
+        _prepend_sample(false, values.ADC),
+        _prepend_sample(false, values.excitation_bool),
+        _prepend_sample(_scalar_getindex(values.t, firstindex(values.t)), values.t),
+        _prepend_sample(zero(eltype(values.Δt)), values.Δt),
+    )
+end
+
 function same_boundary_sample(out, values)
     return all(last(dst) == first(src) for (dst, src) in zip(table_columns(out), table_columns(values)))
 end
@@ -55,11 +80,15 @@ end
 
 # -- 6.3. Sample the full sequence ------------------------------------------
 function sample_sequence(seq; motion=NoMotion(), sampling_rule=MaxStepSizeRule(1e-3, 5e-5), freq_in_phase=false)
+    T0 = get_block_start_times(seq)
+    global_event_times = merge_sampling_times(sequence_boundary_sampling_times(seq), motion_sampling_times(seq, motion))
+    if length(seq) == 1
+        values = sample_sequence_block(seq, 1; sampling_rule, motion_times=block_global_event_times(T0, 1, global_event_times), freq_in_phase)
+        return _with_adc_start_padding(values)
+    end
     out = DiscreteSequence()
     sizehint = max(8length(seq), 5sum(seq.ADC.N))
     foreach(x -> Base.sizehint!(x, sizehint), (out.t, table_columns(out)..., out.excitation_bool, out.Δt))
-    T0 = get_block_start_times(seq)
-    global_event_times = merge_sampling_times(sequence_boundary_sampling_times(seq), motion_sampling_times(seq, motion))
     for block in 1:length(seq)
         values = sample_sequence_block(seq, block; sampling_rule, motion_times=block_global_event_times(T0, block, global_event_times), freq_in_phase)
         append_sampled_block!(out, values, T0[block])

--- a/KomaMRIBase/src/discretization/WaveformInterpolation.jl
+++ b/KomaMRIBase/src/discretization/WaveformInterpolation.jl
@@ -6,8 +6,9 @@
 # sampling grid.
 
 function linear_interpolate_samples(samples, t; default=zero(eltype(samples.A)), interpolate=true)
-    out = Vector{typeof(default)}(undef, length(t))
-    isempty(samples.t) && return fill!(out, default)
+    out = similar(samples.A, typeof(default), length(t))
+    fill!(out, default)
+    (isempty(samples.t) || isempty(samples.A)) && return out
     last_sample = min(lastindex(samples.t), lastindex(samples.A))
     sample = firstindex(samples.t)
     i = firstindex(t)
@@ -27,16 +28,17 @@ function linear_interpolate_samples(samples, t; default=zero(eltype(samples.A)),
             end
             for k in i:j
                 l = interpolate ? min(sample + k - i, sample_end) : sample_end - (j - k)
-                out[k] = l >= sample ? samples.A[l] : default
+                l >= sample && _scalar_setindex!(out, _scalar_getindex(samples.A, l), k)
             end
             sample = sample_end + 1
-        elseif !interpolate || ti < first(samples.t) || sample > last_sample
-            out[i:j] .= default
-        else
+        elseif interpolate && ti >= first(samples.t) && sample <= last_sample
             lo_time, hi_time = samples.t[sample - 1], samples.t[sample]
             w = (ti - lo_time) / (hi_time - lo_time)
-            value = samples.A[sample - 1] + (samples.A[sample] - samples.A[sample - 1]) * w
-            out[i:j] .= value
+            lo = _scalar_getindex(samples.A, sample - 1)
+            value = lo + (_scalar_getindex(samples.A, sample) - lo) * w
+            for k in i:j
+                _scalar_setindex!(out, value, k)
+            end
         end
         i = j + 1
     end

--- a/KomaMRIBase/src/discretization/WaveformInterpolation.jl
+++ b/KomaMRIBase/src/discretization/WaveformInterpolation.jl
@@ -28,16 +28,16 @@ function linear_interpolate_samples(samples, t; default=zero(eltype(samples.A)),
             end
             for k in i:j
                 l = interpolate ? min(sample + k - i, sample_end) : sample_end - (j - k)
-                l >= sample && _scalar_setindex!(out, _scalar_getindex(samples.A, l), k)
+                l >= sample && (out[k] = samples.A[l])
             end
             sample = sample_end + 1
         elseif interpolate && ti >= first(samples.t) && sample <= last_sample
             lo_time, hi_time = samples.t[sample - 1], samples.t[sample]
             w = (ti - lo_time) / (hi_time - lo_time)
-            lo = _scalar_getindex(samples.A, sample - 1)
-            value = lo + (_scalar_getindex(samples.A, sample) - lo) * w
+            lo = samples.A[sample - 1]
+            value = lo + (samples.A[sample] - lo) * w
             for k in i:j
-                _scalar_setindex!(out, value, k)
+                out[k] = value
             end
         end
         i = j + 1

--- a/KomaMRICore/src/simulation/SimulatorCore.jl
+++ b/KomaMRICore/src/simulation/SimulatorCore.jl
@@ -278,8 +278,12 @@ end
 function get_sim_ranges(seqd::DiscreteSequence; max_block_length=Inf, max_rf_block_length=Inf, eval_intervals_per_step=1)
     ranges, ranges_bool = UnitRange{Int}[], Bool[]; isempty(seqd.Δt) && return ranges, ranges_bool
 
-    starts = [firstindex(seqd.Δt); findall(seqd.excitation_bool[2:end] .!= seqd.excitation_bool[1:(end - 1)]) .+ 1]
-    stops = [starts[2:end] .- 1; lastindex(seqd.Δt)]
+    starts = Int[firstindex(seqd.Δt)]
+    for i in (firstindex(seqd.excitation_bool) + 1):lastindex(seqd.excitation_bool)
+        seqd.excitation_bool[i] == seqd.excitation_bool[i - 1] || push!(starts, i)
+    end
+    stops = [starts[i] - 1 for i in 2:length(starts)]
+    push!(stops, lastindex(seqd.Δt))
     for (start, stop) in zip(starts, stops)
         is_excitation = seqd.excitation_bool[start]
         max_length = is_excitation ? max_rf_block_length : max_block_length


### PR DESCRIPTION
## Summary

- make single-block sequence discretization traceable through Reactant, including RF waveform interpolation and ADC-at-start padding
- add a narrow `KomaMRIBase` Reactant extension for traced RF arrays while preserving the existing native discretization path
- differentiate an acquired-signal loss through `discretize`, `get_sim_ranges`, and the `BlochSimple` time iterator

## Validation

- focused CPU Reactant + Enzyme ADC test: `16/16`
- `KomaMRIBase`: `767/767`
- full unfiltered `KomaMRICore` CPU suite: `448/448`
- `KomaMRIFiles`: `24448/24448`
- Titan RTX CUDA: existing parallel BlochSimple Reactant + Enzyme test `4/4`; new discretize + ADC + iterator test `2/2`
- CUDA gradient matched a fifth-order central finite-difference baseline at `rtol=1e-8`, `atol=1e-10`
- `git diff --check`

Stacked on #922.
