### PR TITLE
Enable Reactant AD through simulate

### DIFF
--- a/KomaMRICore/src/simulation/SimulatorCore.jl
+++ b/KomaMRICore/src/simulation/SimulatorCore.jl
@@ -384,7 +384,8 @@ function simulate(
     if sim_params["gpu"]
         sim_params["Nthreads"] = 1
     end
-    sig = zeros(ComplexF64, Ndims..., sim_params["Nthreads"])
+    sig = similar(obj.ρ, ComplexF64, Ndims..., sim_params["Nthreads"])
+    fill!(sig, 0)
     supports_float64 = KA.supports_float64(backend)
     if sim_params["gpu"] && sim_params["precision"] == "bigfloat"
         set_precision_fallback!(sim_params, backend, supports_float64 ? "f64" : "f32")
@@ -428,11 +429,13 @@ function simulate(
         sim_params,
         callbacks=all_callbacks,
     )
-    # Result to CPU, if already in the CPU it does nothing
-    sig = sig |> cpu
+    # Result to CPU
+    if sim_params["gpu"]
+        sig = sig |> cpu
+        Xt = Xt |> cpu
+    end
     sig = sum(sig; dims=length(Ndims) + 1) #Sum over threads, no-op for gpu (Nthreads=1)
     sig .*= get_adc_phase_compensation(seq)
-    Xt = Xt |> cpu
     # Output
     if sim_params["return_type"] == "state"
         out = Xt

--- a/KomaMRICore/test/reactant_cuda.jl
+++ b/KomaMRICore/test/reactant_cuda.jl
@@ -114,12 +114,7 @@ function reactant_cuda_sequence(rf_scale)
     )
 end
 
-function reactant_cuda_discretize_loss(rf_scale)
-    seqd = discretize(
-        reactant_cuda_sequence(rf_scale);
-        sampling_rule=MaxStepSizeRule(1e-3, 0.2e-3),
-    )
-    parts, excitation_bool = KomaMRICore.get_sim_ranges(seqd)
+function reactant_cuda_simulate_loss(rf_scale)
     zeros2 = zero.(rf_scale[1:2])
     density = reactant_cuda_traced_vector(rf_scale, [1.0, 0.75])
     obj = Phantom(
@@ -129,25 +124,26 @@ function reactant_cuda_discretize_loss(rf_scale)
         T2=0.1 .* one.(density),
         Δw=copy(zeros2),
     )
-    M = Mag(complex.(zeros2), copy(density))
-    signal = similar(rf_scale, ComplexF64, sum(seqd.ADC), 1, 1)
-    KomaMRICore.run_sim_time_iter!(
+    sim_params = Dict{String,Any}(
+        "sim_method" => BlochSimple(),
+        "gpu" => false,
+        "Nthreads" => 1,
+        "return_type" => "mat",
+        "precision" => "f64",
+        "sampling_rule" => MaxStepSizeRule(1e-3, 0.2e-3),
+    )
+    signal = simulate(
         obj,
-        seqd,
-        signal,
-        M,
-        BlochSimple(),
-        KomaMRICore.KA.CPU();
-        parts,
-        excitation_bool,
-        Nblocks=length(parts),
-        Nthreads=1,
+        reactant_cuda_sequence(rf_scale),
+        Scanner();
+        sim_params,
+        verbose=false,
     )
     return sum(abs2, signal)
 end
 
-reactant_cuda_discretize_gradient(rf) =
-    Enzyme.gradient(Enzyme.ReverseWithPrimal, reactant_cuda_discretize_loss, rf).derivs[1]
+reactant_cuda_simulate_gradient(rf) =
+    Enzyme.gradient(Enzyme.ReverseWithPrimal, reactant_cuda_simulate_loss, rf).derivs[1]
 
 @testset "Reactant + Enzyme CUDA through parallel BlochSimple kernels" begin
     devices = Reactant.devices()
@@ -166,17 +162,17 @@ reactant_cuda_discretize_gradient(rf) =
     @test Array(compiled_gradient(rf)) ≈ finite_difference rtol=1e-8 atol=1e-10
 end
 
-@testset "Reactant + Enzyme CUDA through discretize, ADC, and BlochSimple iterator" begin
+@testset "Reactant + Enzyme CUDA through simulate with ADC and BlochSimple" begin
     rf = Reactant.to_rarray(REACTANT_CUDA_RF0)
-    compiled_loss = Reactant.@compile sync=true reactant_cuda_discretize_loss(rf)
-    compiled_gradient = Reactant.@compile sync=true reactant_cuda_discretize_gradient(rf)
+    compiled_loss = Reactant.@compile sync=true reactant_cuda_simulate_loss(rf)
+    compiled_gradient = Reactant.@compile sync=true reactant_cuda_simulate_gradient(rf)
     finite_difference = FiniteDifferences.grad(
         FiniteDifferences.central_fdm(5, 1),
-        reactant_cuda_discretize_loss,
+        reactant_cuda_simulate_loss,
         REACTANT_CUDA_RF0,
     )[1]
 
     @test Reactant.to_number(compiled_loss(rf)) ≈
-        reactant_cuda_discretize_loss(REACTANT_CUDA_RF0)
+        reactant_cuda_simulate_loss(REACTANT_CUDA_RF0)
     @test Array(compiled_gradient(rf)) ≈ finite_difference rtol=1e-8 atol=1e-10
 end

--- a/KomaMRICore/test/runtests.jl
+++ b/KomaMRICore/test/runtests.jl
@@ -727,34 +727,6 @@ end
         end
     end
 
-    if run_broken_sequence_probe(:reactant, :enzyme)
-        import Enzyme
-        import Reactant
-
-        Reactant.set_default_backend("cpu")
-        Reactant.allowscalar(false)
-
-        Core.eval(@__MODULE__, quote
-            function reactant_enzyme_blochsimple_ad_gradient(rf_scale)
-                result = Enzyme.gradient(Enzyme.ReverseWithPrimal, blochsimple_ad_loss, rf_scale)
-                return result.derivs[1]
-            end
-
-            function run_reactant_enzyme_blochsimple_ad_probe()
-                rf_ra = Reactant.to_rarray(copy(BLOCHSIMPLE_AD_RF0))
-                compiled = Reactant.@compile sync=true reactant_enzyme_blochsimple_ad_gradient(rf_ra)
-                return blochsimple_ad_gradient_matches_fd(Array(compiled(rf_ra)))
-            end
-        end)
-
-        @testset "BlochSimple CPU Reactant Enzyme AD probe" begin
-            probe = Base.invokelatest(
-                getfield, @__MODULE__, :run_reactant_enzyme_blochsimple_ad_probe,
-            )
-            @test_broken Base.invokelatest(probe)
-        end
-    end
-
     if run_broken_sequence_probe(:mooncake)
         import DifferentiationInterface
         import Mooncake
@@ -781,24 +753,24 @@ end
         Reactant.allowscalar(false)
 
         Core.eval(@__MODULE__, quote
-            function reactant_enzyme_discretize_loss_and_gradient(rf_scale)
+            function reactant_enzyme_simulate_loss_and_gradient(rf_scale)
                 result = Enzyme.gradient(
                     Enzyme.ReverseWithPrimal,
-                    blochsimple_discretize_ad_loss,
+                    blochsimple_simulate_ad_loss,
                     rf_scale,
                 )
                 return result.val, result.derivs[1]
             end
 
-            function run_reactant_enzyme_discretize_probe()
+            function run_reactant_enzyme_simulate_probe()
                 rf = Reactant.to_rarray(copy(BLOCHSIMPLE_DISCRETIZE_AD_RF0))
-                compiled = Reactant.@compile sync=true reactant_enzyme_discretize_loss_and_gradient(rf)
+                compiled = Reactant.@compile sync=true reactant_enzyme_simulate_loss_and_gradient(rf)
                 loss, gradient = compiled(rf)
                 return Reactant.to_number(loss), Array(gradient)
             end
         end)
 
-        @testset "Sequence discretization and ADC through BlochSimple iterator Reactant Enzyme" begin
+        @testset "Sequence and ADC through simulate with BlochSimple Reactant Enzyme" begin
             rf0 = copy(BLOCHSIMPLE_DISCRETIZE_AD_RF0)
             seqd = discretize(
                 blochsimple_discretize_ad_sequence(rf0);
@@ -808,7 +780,7 @@ end
             probe = Base.invokelatest(
                 getfield,
                 @__MODULE__,
-                :run_reactant_enzyme_discretize_probe,
+                :run_reactant_enzyme_simulate_probe,
             )
             reactant_loss, reactant_gradient = Base.invokelatest(probe)
 
@@ -817,8 +789,8 @@ end
             @test sum(seqd.ADC) == 3
             @test seqd.ADC[1:2] == [false, true]
             @test seqd.t[1:2] == [0.0, 0.0]
-            @test reactant_loss ≈ blochsimple_discretize_ad_loss(rf0)
-            @test reactant_gradient ≈ blochsimple_discretize_ad_fd_gradient(rf0) rtol=1e-8 atol=1e-10
+            @test reactant_loss ≈ blochsimple_simulate_ad_loss(rf0)
+            @test reactant_gradient ≈ blochsimple_simulate_ad_fd_gradient(rf0) rtol=1e-8 atol=1e-10
         end
 
         T = Float32

--- a/KomaMRICore/test/test_files/ad_utils.jl
+++ b/KomaMRICore/test/test_files/ad_utils.jl
@@ -79,12 +79,7 @@ function blochsimple_discretize_ad_sequence(rf_scale; adc_delay=0.0)
     )
 end
 
-function blochsimple_discretize_ad_loss(rf_scale)
-    seqd = discretize(
-        blochsimple_discretize_ad_sequence(rf_scale);
-        sampling_rule=MaxStepSizeRule(1e-3, 0.2e-3),
-    )
-    parts, excitation_bool = KomaMRICore.get_sim_ranges(seqd)
+function blochsimple_simulate_ad_loss(rf_scale)
     zeros2 = zero.(rf_scale[1:2])
     density = blochsimple_discretize_ad_vector(rf_scale, (1.0, 0.75))
     obj = Phantom(
@@ -94,22 +89,23 @@ function blochsimple_discretize_ad_loss(rf_scale)
         T2=0.1 .* one.(density),
         Δw=copy(zeros2),
     )
-    magnetization = KomaMRICore.Mag(complex.(zeros2), copy(density))
-    signal = similar(rf_scale, ComplexF64, sum(seqd.ADC), 1, 1)
-    KomaMRICore.run_sim_time_iter!(
+    sim_params = Dict{String,Any}(
+        "sim_method" => KomaMRICore.BlochSimple(),
+        "gpu" => false,
+        "Nthreads" => 1,
+        "return_type" => "mat",
+        "precision" => "f64",
+        "sampling_rule" => MaxStepSizeRule(1e-3, 0.2e-3),
+    )
+    signal = simulate(
         obj,
-        seqd,
-        signal,
-        magnetization,
-        KomaMRICore.BlochSimple(),
-        KomaMRICore.KA.CPU();
-        parts,
-        excitation_bool,
-        Nblocks=length(parts),
-        Nthreads=1,
+        blochsimple_discretize_ad_sequence(rf_scale),
+        Scanner();
+        sim_params,
+        verbose=false,
     )
     return sum(abs2, signal)
 end
 
-blochsimple_discretize_ad_fd_gradient(rf_scale=BLOCHSIMPLE_DISCRETIZE_AD_RF0) =
-    grad(central_fdm(5, 1), blochsimple_discretize_ad_loss, rf_scale)[1]
+blochsimple_simulate_ad_fd_gradient(rf_scale=BLOCHSIMPLE_DISCRETIZE_AD_RF0) =
+    grad(central_fdm(5, 1), blochsimple_simulate_ad_loss, rf_scale)[1]


### PR DESCRIPTION
## Summary

- keep `simulate` signal and state storage traceable instead of unconditionally materializing CPU arrays
- differentiate an RF-scale loss through the public `simulate` pipeline, including sequence discretization, ADC sampling, and `BlochSimple`
- cover both Reactant CPU and CUDA execution with Enzyme gradients checked against finite differences

## Stack

This is PR 4 of 4, stacked directly on #924. Review only commit `a57b59092` for this layer.

## Validation

- `TEST_GROUP=reactant Pkg.test("KomaMRICore")`: 16/16 passed
- `Pkg.test("KomaMRICore")`: 448/448 passed
- Titan RTX via Reactant/XLA: kernel path 4/4 passed
- Titan RTX via Reactant/XLA: public `simulate` + ADC path 2/2 passed