### PR TITLE
Reduce GPU precompile workloads

### DIFF
--- a/KomaMRICore/Project.toml
+++ b/KomaMRICore/Project.toml
@@ -1,7 +1,7 @@
 name = "KomaMRICore"
 uuid = "4baa4f4d-2ae9-40db-8331-a7d1080e3f4e"
 authors = ["Carlos Castillo Passi <cncastillo@uc.cl>"]
-version = "0.12.4"
+version = "0.12.5"
 
 [deps]
 AcceleratedKernels = "6a4ca0a5-0e36-4168-a932-d9be78d558f1"

--- a/KomaMRICore/ext/KomaAMDGPUExt.jl
+++ b/KomaMRICore/ext/KomaAMDGPUExt.jl
@@ -48,13 +48,10 @@ import KomaMRIBase: PulseDesigner as PD
         
         sim_methods = [
             Bloch(),
-            BlochSimple(),
-            BlochMagnus1(),
             BlochMagnus2(),
             BlochMagnus4(),
-            BlochMagnus6(),
         ]
-        precisions = ["f32", "f64"]
+        precisions = ["f32"]
         return_types = ["mat", "raw"]
         
         for sim_method in sim_methods

--- a/KomaMRICore/ext/KomaCUDAExt.jl
+++ b/KomaMRICore/ext/KomaCUDAExt.jl
@@ -31,51 +31,51 @@ end
 using PrecompileTools: @setup_workload, @compile_workload
 import KomaMRIBase: PulseDesigner as PD
 
-@setup_workload begin
-    KomaMRICore.BACKEND[] = CUDABackend()
-    @compile_workload begin
-        using KomaMRIBase
-        using KomaMRICore
-        
-        sys = Scanner()
-        obj_minimal = Phantom(
-            x=[0.0, 1e-3],
-            y=[0.0, 0.0],
-            z=[0.0, 0.0],
-            ρ=[1.0, 1.0],
-            T1=[0.8, 0.8],
-            T2=[80e-3, 80e-3],
-            T2s=[80e-3, 80e-3]
-        )
-        
-        seq = PD.build_test_seq()
-        
-        sim_methods = [
-            Bloch(),
-            BlochSimple(),
-            BlochMagnus1(),
-            BlochMagnus2(),
-            BlochMagnus4(),
-            BlochMagnus6(),
-        ]
-        precisions = ["f32", "f64"]
-        return_types = ["mat", "raw"]
-        
-        for sim_method in sim_methods
-            for precision in precisions
-                for return_type in return_types
-                    sim_params = Dict{String,Any}(
-                        "sim_method" => sim_method,
-                        "precision" => precision,
-                        "return_type" => return_type,
-                        "gpu" => true
-                    )
-                    signal = simulate(obj_minimal, seq, sys; sim_params, verbose=false)
+# CUDA.jl's persistent compiler cache requires Julia 1.11 or later.
+if VERSION >= v"1.11"
+    @setup_workload begin
+        KomaMRICore.BACKEND[] = CUDABackend()
+        @compile_workload begin
+            using KomaMRIBase
+            using KomaMRICore
+
+            sys = Scanner()
+            obj_minimal = Phantom(
+                x=[0.0, 1e-3],
+                y=[0.0, 0.0],
+                z=[0.0, 0.0],
+                ρ=[1.0, 1.0],
+                T1=[0.8, 0.8],
+                T2=[80e-3, 80e-3],
+                T2s=[80e-3, 80e-3]
+            )
+
+            seq = PD.build_test_seq()
+
+            sim_methods = [
+                Bloch(),
+                BlochMagnus2(),
+                BlochMagnus4(),
+            ]
+            precisions = ["f32"]
+            return_types = ["mat", "raw"]
+
+            for sim_method in sim_methods
+                for precision in precisions
+                    for return_type in return_types
+                        sim_params = Dict{String,Any}(
+                            "sim_method" => sim_method,
+                            "precision" => precision,
+                            "return_type" => return_type,
+                            "gpu" => true
+                        )
+                        signal = simulate(obj_minimal, seq, sys; sim_params, verbose=false)
+                    end
                 end
             end
         end
+        KomaMRICore.BACKEND[] = nothing
     end
-    KomaMRICore.BACKEND[] = nothing
 end
 
 end

--- a/KomaMRICore/ext/KomaMetalExt.jl
+++ b/KomaMRICore/ext/KomaMetalExt.jl
@@ -51,15 +51,10 @@ import KomaMRIBase: PulseDesigner as PD
         
         sim_methods = [
             Bloch(),
-            # BlochSimple uses MPSGraph reductions, but Metal.__init__ does not run
-            # while generating the extension cache, so MPSGraph is unavailable.
-            # BlochSimple(),
-            BlochMagnus1(),
             BlochMagnus2(),
             BlochMagnus4(),
-            BlochMagnus6(),
         ]
-        precisions = ["f32", "f64"]
+        precisions = ["f32"]
         return_types = ["mat", "raw"]
         
         for sim_method in sim_methods

--- a/KomaMRICore/ext/KomaoneAPIExt.jl
+++ b/KomaMRICore/ext/KomaoneAPIExt.jl
@@ -48,13 +48,10 @@ import KomaMRIBase: PulseDesigner as PD
         
         sim_methods = [
             Bloch(),
-            BlochSimple(),
-            BlochMagnus1(),
             BlochMagnus2(),
             BlochMagnus4(),
-            BlochMagnus6(),
         ]
-        precisions = ["f32", "f64"]
+        precisions = ["f32"]
         return_types = ["mat", "raw"]
         
         for sim_method in sim_methods


### PR DESCRIPTION
## Summary
- restrict GPU precompile workloads to `f32`, `Bloch`, `BlochMagnus2`, and `BlochMagnus4`
- skip the CUDA precompile workload on Julia 1.10, where the persistent CUDA compiler cache is unavailable
- bump KomaMRICore to 0.12.5

## Testing
- parsed all four edited extension files with Julia
- parsed `KomaMRICore/Project.toml`
- ran `git diff --check`

GPU CI is requested with the `run-gpu-ci` label.