### PR TITLE
Use shallow checkouts for GPU CI jobs

### DIFF
--- a/.buildkite/runbenchmarks.yml
+++ b/.buildkite/runbenchmarks.yml
@@ -3,6 +3,10 @@ steps:
     steps:
       - label: "AMDGPU - Julia 1 - Benchmark"
         plugins:
+          - sparse-checkout#v1.8.0:
+              paths:
+                - "/*"
+              no_cone: true
           - JuliaCI/julia#v1:
               version: "1"
         command: |
@@ -30,6 +34,10 @@ steps:
 
       - label: "CUDA - Julia 1 - Benchmark"
         plugins:
+          - sparse-checkout#v1.8.0:
+              paths:
+                - "/*"
+              no_cone: true
           - JuliaCI/julia#v1:
               version: "1"
         command: |
@@ -58,6 +66,10 @@ steps:
 
       - label: "oneAPI - Julia 1 - Benchmark"
         plugins:
+          - sparse-checkout#v1.8.0:
+              paths:
+                - "/*"
+              no_cone: true
           - JuliaCI/julia#v1:
               version: "1"
         command: |
@@ -86,6 +98,10 @@ steps:
 
       - label: "Metal - Julia 1 - Benchmark"
         plugins:
+          - sparse-checkout#v1.8.0:
+              paths:
+                - "/*"
+              no_cone: true
           - JuliaCI/julia#v1:
               version: "1"
         command: |
@@ -114,6 +130,10 @@ steps:
 
       - label: "Combine benchmarks"
         plugins:
+          - sparse-checkout#v1.8.0:
+              paths:
+                - "/*"
+              no_cone: true
           - JuliaCI/julia#v1:
               version: "1"
         command: |

--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -8,6 +8,10 @@ steps:
               - "1.10"
               - "1"
         plugins:
+          - sparse-checkout#v1.8.0:
+              paths:
+                - "/*"
+              no_cone: true
           - JuliaCI/julia#v1:
               version: "{{matrix.version}}"
           - JuliaCI/julia-coverage:
@@ -52,6 +56,10 @@ steps:
               - "1.10"
               - "1"
         plugins:
+          - sparse-checkout#v1.8.0:
+              paths:
+                - "/*"
+              no_cone: true
           - JuliaCI/julia#v1:
               version: "{{matrix.version}}"
           - JuliaCI/julia-coverage:
@@ -95,6 +103,10 @@ steps:
               - "1.10"
               - "1"
         plugins:
+          - sparse-checkout#v1.8.0:
+              paths:
+                - "/*"
+              no_cone: true
           - JuliaCI/julia#v1:
               version: "{{matrix.version}}"
           - JuliaCI/julia-coverage:
@@ -140,6 +152,10 @@ steps:
               - "1.10"
               - "1"
         plugins:
+          - sparse-checkout#v1.8.0:
+              paths:
+                - "/*"
+              no_cone: true
           - JuliaCI/julia#v1:
               version: "{{matrix.version}}"
         env:


### PR DESCRIPTION
## Summary

- Run the dynamically uploaded GPU test and benchmark jobs from depth-1, blob-filtered checkouts.
- Materialize the complete current tree so Julia workspace members and test fixtures remain available.
- Apply the checkout to all four backend test definitions and all five benchmark steps.

## Why

The CUDA agent repeatedly exhausted disk while cloning 665–707 MiB of repository history, then failed again while installing `CUDA_Runtime`. A depth-1 checkout is about 244 MiB with the complete working tree.

## Testing

- Parsed `.buildkite/runtests.yml` and `.buildkite/runbenchmarks.yml` with Ruby/Psych.
- Simulated the plugin checkout locally: one commit, zero excluded tracked files, 244 MiB checkout.
- `git diff --check`
