### PR TITLE
Fix GPU precompile without device

### DIFF
--- a/KomaMRICore/ext/KomaCUDAExt.jl
+++ b/KomaMRICore/ext/KomaCUDAExt.jl
@@ -34,47 +34,49 @@ import KomaMRIBase: PulseDesigner as PD
 # CUDA.jl's persistent compiler cache requires Julia 1.11 or later.
 if VERSION >= v"1.11"
     @setup_workload begin
-        KomaMRICore.BACKEND[] = CUDABackend()
-        @compile_workload begin
-            using KomaMRIBase
-            using KomaMRICore
+        if CUDA.functional()
+            KomaMRICore.BACKEND[] = CUDABackend()
+            @compile_workload begin
+                using KomaMRIBase
+                using KomaMRICore
 
-            sys = Scanner()
-            obj_minimal = Phantom(
-                x=[0.0, 1e-3],
-                y=[0.0, 0.0],
-                z=[0.0, 0.0],
-                ρ=[1.0, 1.0],
-                T1=[0.8, 0.8],
-                T2=[80e-3, 80e-3],
-                T2s=[80e-3, 80e-3]
-            )
+                sys = Scanner()
+                obj_minimal = Phantom(
+                    x=[0.0, 1e-3],
+                    y=[0.0, 0.0],
+                    z=[0.0, 0.0],
+                    ρ=[1.0, 1.0],
+                    T1=[0.8, 0.8],
+                    T2=[80e-3, 80e-3],
+                    T2s=[80e-3, 80e-3]
+                )
 
-            seq = PD.build_test_seq()
+                seq = PD.build_test_seq()
 
-            sim_methods = [
-                Bloch(),
-                BlochMagnus2(),
-                BlochMagnus4(),
-            ]
-            precisions = ["f32"]
-            return_types = ["mat", "raw"]
+                sim_methods = [
+                    Bloch(),
+                    BlochMagnus2(),
+                    BlochMagnus4(),
+                ]
+                precisions = ["f32"]
+                return_types = ["mat", "raw"]
 
-            for sim_method in sim_methods
-                for precision in precisions
-                    for return_type in return_types
-                        sim_params = Dict{String,Any}(
-                            "sim_method" => sim_method,
-                            "precision" => precision,
-                            "return_type" => return_type,
-                            "gpu" => true
-                        )
-                        signal = simulate(obj_minimal, seq, sys; sim_params, verbose=false)
+                for sim_method in sim_methods
+                    for precision in precisions
+                        for return_type in return_types
+                            sim_params = Dict{String,Any}(
+                                "sim_method" => sim_method,
+                                "precision" => precision,
+                                "return_type" => return_type,
+                                "gpu" => true
+                            )
+                            signal = simulate(obj_minimal, seq, sys; sim_params, verbose=false)
+                        end
                     end
                 end
             end
+            KomaMRICore.BACKEND[] = nothing
         end
-        KomaMRICore.BACKEND[] = nothing
     end
 end
 


### PR DESCRIPTION
Make the execution of the CUDA precompilation simulation conditional on CUDA being functional. Otherwise precompilation of KomaMRI fails on a CPU-only machine where CUDA is installed. This fix was developed for a local project using KomaMRI, and I verified that it worked on a clean checkout of KomaMRI. 

Fixes #949.

Generated-by: Codex